### PR TITLE
Score capture tweak

### DIFF
--- a/src/board/movegen/movepicker.rs
+++ b/src/board/movegen/movepicker.rs
@@ -137,24 +137,23 @@ impl<const CAPTURES_ONLY: bool, const DO_SEE: bool, const ROOT: bool>
     }
 
     pub fn score_capture(_t: &ThreadData, pos: &Board, m: Move, see_threshold: i32) -> i32 {
-        let mut score;
         if m.is_promo() {
             if m.promotion_type() == PieceType::QUEEN {
-                score = lookups::get_mvv_lva_score(PieceType::QUEEN, PieceType::PAWN);
-            } else {
-                score = -WINNING_CAPTURE_SCORE; // basically no point looking at these.
+                return lookups::get_mvv_lva_score(PieceType::QUEEN, PieceType::PAWN) + WINNING_CAPTURE_SCORE;
             }
-        } else if m.is_ep() {
-            score = 1050; // the score for PxP in MVVLVA
-        } else {
-            score = lookups::get_mvv_lva_score(pos.captured_piece(m).piece_type(), pos.piece_at(m.from()).piece_type());
+            return -WINNING_CAPTURE_SCORE; // basically no point looking at these.
         }
+
+        let mut score = if m.is_ep() {
+            lookups::get_mvv_lva_score(PieceType::PAWN, PieceType::PAWN)
+        } else {
+            lookups::get_mvv_lva_score(pos.captured_piece(m).piece_type(), pos.piece_at(m.from()).piece_type())
+        };
+
         if !DO_SEE || pos.static_exchange_eval(m, see_threshold) {
             score += WINNING_CAPTURE_SCORE;
         }
-        if m.is_promo() && m.promotion_type() == PieceType::QUEEN {
-            score += WINNING_CAPTURE_SCORE / 2;
-        }
+        
         score
     }
 }

--- a/src/board/movegen/movepicker.rs
+++ b/src/board/movegen/movepicker.rs
@@ -137,17 +137,19 @@ impl<const CAPTURES_ONLY: bool, const DO_SEE: bool, const ROOT: bool>
     }
 
     pub fn score_capture(_t: &ThreadData, pos: &Board, m: Move, see_threshold: i32) -> i32 {
-        let mut score = if m.is_promo() {
+        const QUEEN_PROMO_BONUS: i32 = lookups::get_mvv_lva_score(PieceType::QUEEN, PieceType::PAWN);
+        let mut score = if m.is_ep() {
+            lookups::get_mvv_lva_score(PieceType::PAWN, PieceType::PAWN)
+        } else {
+            lookups::get_mvv_lva_score(pos.captured_piece(m).piece_type(), pos.moved_piece(m).piece_type())
+        };
+        if m.is_promo() {
             if m.promotion_type() == PieceType::QUEEN {
-                lookups::get_mvv_lva_score(PieceType::QUEEN, PieceType::PAWN) + WINNING_CAPTURE_SCORE / 2
+                score += QUEEN_PROMO_BONUS;
             } else {
                 return -WINNING_CAPTURE_SCORE; // basically no point looking at these.
             }
-        } else if m.is_ep() {
-            1050 // the score for PxP in MVVLVA
-        } else {
-            lookups::get_mvv_lva_score(pos.captured_piece(m).piece_type(), pos.piece_at(m.from()).piece_type())
-        };
+        }
         if !DO_SEE || pos.static_exchange_eval(m, see_threshold) {
             score += WINNING_CAPTURE_SCORE;
         }

--- a/src/board/movegen/movepicker.rs
+++ b/src/board/movegen/movepicker.rs
@@ -137,23 +137,20 @@ impl<const CAPTURES_ONLY: bool, const DO_SEE: bool, const ROOT: bool>
     }
 
     pub fn score_capture(_t: &ThreadData, pos: &Board, m: Move, see_threshold: i32) -> i32 {
-        if m.is_promo() {
+        let mut score = if m.is_promo() {
             if m.promotion_type() == PieceType::QUEEN {
-                return lookups::get_mvv_lva_score(PieceType::QUEEN, PieceType::PAWN) + WINNING_CAPTURE_SCORE;
+                lookups::get_mvv_lva_score(PieceType::QUEEN, PieceType::PAWN) + WINNING_CAPTURE_SCORE / 2
+            } else {
+                return -WINNING_CAPTURE_SCORE; // basically no point looking at these.
             }
-            return -WINNING_CAPTURE_SCORE; // basically no point looking at these.
-        }
-
-        let mut score = if m.is_ep() {
-            lookups::get_mvv_lva_score(PieceType::PAWN, PieceType::PAWN)
+        } else if m.is_ep() {
+            1050 // the score for PxP in MVVLVA
         } else {
             lookups::get_mvv_lva_score(pos.captured_piece(m).piece_type(), pos.piece_at(m.from()).piece_type())
         };
-
         if !DO_SEE || pos.static_exchange_eval(m, see_threshold) {
             score += WINNING_CAPTURE_SCORE;
         }
-        
         score
     }
 }

--- a/src/lookups.rs
+++ b/src/lookups.rs
@@ -146,12 +146,12 @@ pub static PIECE_MAJ: [bool; 13] =
 pub static PIECE_MIN: [bool; 13] =
     [false, false, true, true, false, false, false, false, true, true, false, false, false];
 
-fn victim_score(piece: PieceType) -> i32 {
-    i32::from(piece.inner()) * 1000
+const fn victim_score(piece: PieceType) -> i32 {
+    piece.inner() as i32 * 1000
 }
 
 /// The score of this pair of pieces, for MVV/LVA move ordering.
-pub fn get_mvv_lva_score(victim: PieceType, attacker: PieceType) -> i32 {
+pub const fn get_mvv_lva_score(victim: PieceType, attacker: PieceType) -> i32 {
     victim_score(victim) + 60 - victim_score(attacker) / 100
 }
 


### PR DESCRIPTION
```
Score of score-capture-tweak vs dev: 1715 - 1654 - 2631  [0.505] 6000
...      score-capture-tweak playing White: 1331 - 396 - 1273  [0.656] 3000
...      score-capture-tweak playing Black: 384 - 1258 - 1358  [0.354] 3000
...      White vs Black: 2589 - 780 - 2631  [0.651] 6000
Elo difference: 3.5 +/- 6.6, LOS: 85.3 %, DrawRatio: 43.9 %
SPRT: llr 0.54 (18.3%), lbound -2.94, ubound 2.94
```
This hasn't passed, but the code is much more pleasing to me so I'm switching to it anyway.