### PR TITLE
flip sign of INFINITY in check

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -589,7 +589,7 @@ impl Board {
         }
 
         let static_eval = if in_check {
-            INFINITY // when we're in check, it could be checkmate, so it's unsound to use evaluate().
+            -INFINITY // when we're in check, it could be checkmate, so it's unsound to use evaluate().
         } else if !excluded.is_null() {
             t.evals[height] // if we're in a singular-verification search, we already have the static eval.
         } else {


### PR DESCRIPTION
```
Score of signflip-bugfix vs dev: 6311 - 6054 - 7635  [0.506] 20000
...      signflip-bugfix playing White: 4270 - 1990 - 3740  [0.614] 10000
...      signflip-bugfix playing Black: 2041 - 4064 - 3895  [0.399] 10000
...      White vs Black: 8334 - 4031 - 7635  [0.608] 20000
Elo difference: 4.5 +/- 3.8, LOS: 99.0 %, DrawRatio: 38.2 %
SPRT: llr 2.38 (81.0%), lbound -2.94, ubound 2.94
```
This didn't pass, but it really should be running with reg bounds anyway, and it's a bugfix, so I'm merging.