### PR TITLE
Unscrewing

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -1244,6 +1244,9 @@ impl Board {
             clippy::cast_sign_loss,
             clippy::cast_possible_truncation
         )]
+        if info.in_game() && info.time_since_start().as_millis() < 50 {
+            return;
+        }
         let sstr = uci::format_score(pv.score);
         let normal_uci_output = !uci::PRETTY_PRINT.load(Ordering::SeqCst);
         let nps = (total_nodes as f64 / info.start_time.elapsed().as_secs_f64()) as u64;

--- a/src/transpositiontable.rs
+++ b/src/transpositiontable.rs
@@ -313,8 +313,7 @@ impl<'a> TTView<'a> {
             .iter()
             .take(1000)
             .filter(|e| {
-                <u64 as Into<TTEntry>>::into(e.load(Ordering::Relaxed)).age_and_flag.flag()
-                    != Bound::None
+                e.load(Ordering::Relaxed) != 0
             })
             .count()
     }


### PR DESCRIPTION
revert `hashfull` recovery strategy and skip in printing uci `info` in low time.
```
Score of report-optimisation vs dev: 2067 - 1830 - 2454  [0.519] 6351
...      report-optimisation playing White: 1324 - 635 - 1215  [0.609] 3174
...      report-optimisation playing Black: 743 - 1195 - 1239  [0.429] 3177
...      White vs Black: 2519 - 1378 - 2454  [0.590] 6351
Elo difference: 13.0 +/- 6.7, LOS: 100.0 %, DrawRatio: 38.6 %
SPRT: llr 2.95 (100.3%), lbound -2.94, ubound 2.94 - H1 was accepted
```