### PR TITLE
Movepicker Early Exit

### DIFF
--- a/src/board/movegen.rs
+++ b/src/board/movegen.rs
@@ -557,7 +557,7 @@ mod tests {
 
         for fen in bench::BENCH_POSITIONS {
             pos.set_from_fen(fen).unwrap();
-            let _ = synced_perft(&mut pos, 2);
+            synced_perft(&mut pos, 2);
         }
     }
 }

--- a/src/board/movegen/movepicker.rs
+++ b/src/board/movegen/movepicker.rs
@@ -86,10 +86,6 @@ impl<const QSEARCH: bool> MovePicker<QSEARCH> {
                 if m.score >= WINNING_CAPTURE_SCORE {
                     return Some(m);
                 }
-                // the move was not winning, so we're going to
-                // generate quiet moves next. As such, we decrement
-                // the index so we can try this move again.
-                self.index -= 1;
             }
             self.stage = if QSEARCH { Stage::Done } else { Stage::YieldKiller1 };
         }
@@ -167,13 +163,19 @@ impl<const QSEARCH: bool> MovePicker<QSEARCH> {
 
         let m = self.movelist.moves[best_num];
 
+        let not_winning = m.score < WINNING_CAPTURE_SCORE;
+
+        if self.skip_quiets && not_winning {
+            // the best we could find wasn't winning, so we're done,
+            // and we're skipping quiet moves, so we're done.
+            return None;
+        }
+
         // swap the best move with the first unsorted move.
         self.movelist.moves.swap(best_num, self.index);
 
         self.index += 1;
-
-        let not_winning = m.score < WINNING_CAPTURE_SCORE;
-        if self.was_tried_lazily(m.mov) || self.skip_quiets && not_winning {
+        if self.was_tried_lazily(m.mov) {
             self.yield_once()
         } else {
             Some(m)

--- a/src/board/movegen/movepicker.rs
+++ b/src/board/movegen/movepicker.rs
@@ -175,7 +175,7 @@ impl<const QSEARCH: bool> MovePicker<QSEARCH> {
         let not_winning = m.score < WINNING_CAPTURE_SCORE;
 
         if self.skip_quiets && not_winning {
-            // the best we could find wasn't winning, so we're done,
+            // the best we could find wasn't winning,
             // and we're skipping quiet moves, so we're done.
             return None;
         }

--- a/src/board/movegen/movepicker.rs
+++ b/src/board/movegen/movepicker.rs
@@ -86,6 +86,10 @@ impl<const QSEARCH: bool> MovePicker<QSEARCH> {
                 if m.score >= WINNING_CAPTURE_SCORE {
                     return Some(m);
                 }
+                // the move was not winning, so we're going to
+                // generate quiet moves next. As such, we decrement
+                // the index so we can try this move again.
+                self.index -= 1;
             }
             self.stage = if QSEARCH { Stage::Done } else { Stage::YieldKiller1 };
         }
@@ -163,6 +167,11 @@ impl<const QSEARCH: bool> MovePicker<QSEARCH> {
 
         let m = self.movelist.moves[best_num];
 
+        // swap the best move with the first unsorted move.
+        self.movelist.moves.swap(best_num, self.index);
+
+        self.index += 1;
+
         let not_winning = m.score < WINNING_CAPTURE_SCORE;
 
         if self.skip_quiets && not_winning {
@@ -170,11 +179,6 @@ impl<const QSEARCH: bool> MovePicker<QSEARCH> {
             // and we're skipping quiet moves, so we're done.
             return None;
         }
-
-        // swap the best move with the first unsorted move.
-        self.movelist.moves.swap(best_num, self.index);
-
-        self.index += 1;
         if self.was_tried_lazily(m.mov) {
             self.yield_once()
         } else {

--- a/src/search.rs
+++ b/src/search.rs
@@ -792,6 +792,7 @@ impl Board {
         let mut tacticals_tried = StackVec::<_, MAX_POSITION_MOVES>::from_default(Move::NULL);
         while let Some(MoveListEntry { mov: m, score: ordering_score }) = move_picker.next(self, t)
         {
+            debug_assert!(!quiets_tried.as_slice().contains(&m) && !tacticals_tried.as_slice().contains(&m));
             if ROOT && uci::is_multipv() {
                 // handle multi-pv
                 if t.multi_pv_excluded.contains(&m) {


### PR DESCRIPTION
```
ELO   | 5.37 +- 4.09 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 13328 W: 3318 L: 3112 D: 6898
```