### PR TITLE
NMP: Guard Scores, Increase Dynamic Range

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -660,7 +660,8 @@ impl Board {
             {
                 let r = info.search_params.nmp_base_reduction
                     + depth / 3
-                    + std::cmp::min((static_eval - beta) / 200, 3);
+                    + std::cmp::min((static_eval - beta) / 200, 3)
+                    + i32::from(improving);
                 let nm_depth = depth - r;
                 self.make_nullmove();
                 let null_score =

--- a/src/search.rs
+++ b/src/search.rs
@@ -660,17 +660,20 @@ impl Board {
             {
                 let r = info.search_params.nmp_base_reduction
                     + depth / 3
-                    + std::cmp::min((static_eval - beta) / 200, 3)
-                    + i32::from(improving);
+                    + std::cmp::min((static_eval - beta) / 200, 4);
                 let nm_depth = depth - r;
                 self.make_nullmove();
-                let null_score =
+                let mut null_score =
                     -self.zw_search::<NNUE>(tt, &mut lpv, info, t, nm_depth, -beta, -beta + 1);
                 self.unmake_nullmove();
                 if info.stopped() {
                     return 0;
                 }
                 if null_score >= beta {
+                    // don't return game-theoretic scores:
+                    if null_score >= MINIMUM_TB_WIN_SCORE {
+                        null_score = beta;
+                    }
                     // unconditionally cutoff if we're just too shallow.
                     if depth < info.search_params.nmp_verification_depth
                         && !is_game_theoretic_score(beta)


### PR DESCRIPTION
```
ELO   | 3.46 +- 2.76 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.01 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 29224 W: 7166 L: 6875 D: 15183
```