### PR TITLE
Remove SEE Pruning in Q Search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ tuning/venv/
 tuning/viridithas
 tuning/log.txt
 .vscode
+.idea
+Viridithas


### PR DESCRIPTION
https://chess.swehosting.se/test/464/
```
ELO   | 1.41 +- 3.82 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [-5.00, 0.00]
GAMES | N: 14536 W: 3362 L: 3303 D: 7871
```

Bench: 2930273