### PR TITLE
Decrement Depth on Fail-High

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -192,7 +192,8 @@ impl Board {
                 info.stopped.store(true, Ordering::SeqCst);
                 break 'deepening;
             }
-            let depth = Depth::new(d.try_into().unwrap());
+            let mut depth = Depth::new(d.try_into().unwrap());
+            let min_depth = (depth / 2).max(ONE_PLY);
             // aspiration loop:
             loop {
                 let nodes_before = info.nodes;
@@ -229,6 +230,8 @@ impl Board {
                     if MAIN_THREAD {
                         info.time_manager.report_aspiration_fail(depth, Bound::Lower);
                     }
+                    // decrement depth:
+                    depth = (depth - 1).max(min_depth);
 
                     if let ControlFlow::Break(_) =
                         info.time_manager.solved_breaker::<MAIN_THREAD>(pv.line[0], 0, d)

--- a/src/search.rs
+++ b/src/search.rs
@@ -231,7 +231,9 @@ impl Board {
                         info.time_manager.report_aspiration_fail(depth, Bound::Lower);
                     }
                     // decrement depth:
-                    depth = (depth - 1).max(min_depth);
+                    if pv.score.abs() < MINIMUM_TB_WIN_SCORE {
+                        depth = (depth - 1).max(min_depth);
+                    }
 
                     if let ControlFlow::Break(_) =
                         info.time_manager.solved_breaker::<MAIN_THREAD>(pv.line[0], 0, d)


### PR DESCRIPTION
```
ELO   | 2.57 +- 2.04 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.94 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 50280 W: 11538 L: 11166 D: 27576
```