### PR TITLE
Only update best-move when alpha is raised.

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -946,10 +946,10 @@ impl Board {
 
             if score > best_score {
                 best_score = score;
-                best_move = m;
                 if score > alpha {
+                    best_move = m;
                     alpha = score;
-                    pv.load_from(best_move, l_pv);
+                    pv.load_from(m, l_pv);
                 }
                 if alpha >= beta {
                     #[cfg(feature = "stats")]

--- a/src/search.rs
+++ b/src/search.rs
@@ -414,10 +414,10 @@ impl Board {
 
             if score > best_score {
                 best_score = score;
-                best_move = m;
                 if score > alpha {
+                    best_move = m;
                     alpha = score;
-                    pv.load_from(best_move, &lpv);
+                    pv.load_from(m, &lpv);
                 }
                 if alpha >= beta {
                     #[cfg(feature = "stats")]


### PR DESCRIPTION
```
ELO   | 3.06 +- 2.35 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.94 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 38240 W: 8881 L: 8544 D: 20815
```