### PR TITLE
Use a greater fraction of the clock increment.

### DIFF
--- a/src/timemgmt.rs
+++ b/src/timemgmt.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 
 const MOVE_OVERHEAD: u64 = 10;
-const DEFAULT_MOVES_TO_GO: u64 = 26;
+const DEFAULT_MOVES_TO_GO: u64 = 25;
 
 #[derive(PartialEq, Eq, Clone, Copy, Debug)]
 pub enum ForcedMoveType {
@@ -86,7 +86,7 @@ impl SearchLimit {
         }
 
         // Otherwise, we use DEFAULT_MOVES_TO_GO.
-        let computed_time_window = our_clock / DEFAULT_MOVES_TO_GO + our_inc / 2 - MOVE_OVERHEAD;
+        let computed_time_window = our_clock / DEFAULT_MOVES_TO_GO + our_inc * 3 / 4 - MOVE_OVERHEAD;
         let hard_time_window = computed_time_window.min(absolute_maximum);
         let optimal_time_window = hard_time_window * 6 / 10;
         (optimal_time_window, hard_time_window, absolute_maximum)


### PR DESCRIPTION
Normal STC:
```
ELO   | 9.03 +- 4.72 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 9736 W: 2408 L: 2155 D: 5173
```
High relative increment TC:
```
ELO   | 16.35 +- 6.40 (95%)
SPRT  | 10.0+0.40s Threads=1 Hash=16MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 5040 W: 1243 L: 1006 D: 2791
```