### PR TITLE
Prevent NMP if TT indicates it will fail.

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -685,6 +685,7 @@ impl Board {
                     >= beta
                 && !t.nmp_banned_for(self.turn())
                 && self.zugzwang_unlikely()
+                && !matches!(tt_hit, Some(TTHit { tt_value: v, tt_bound: b, .. }) if b == Bound::Upper && v < beta)
             {
                 let r = info.search_params.nmp_base_reduction
                     + depth / 3


### PR DESCRIPTION
```
ELO   | 5.66 +- 3.58 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 16992 W: 4139 L: 3862 D: 8991
```