### PR TITLE
Extend singular moves more often.

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -1122,7 +1122,7 @@ impl Board {
 
     /// The reduced beta margin for Singular Extension.
     fn singularity_margin(tt_value: i32, depth: Depth) -> i32 {
-        (tt_value - 2 * depth.round()).max(-MATE_SCORE)
+        (tt_value - depth.round()).max(-MATE_SCORE)
     }
 
     /// Produce extensions when a move is singular - that is, if it is a move that is


### PR DESCRIPTION
STC:
```
ELO   | 1.49 +- 3.92 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [-5.00, 0.00]
GAMES | N: 14200 W: 3373 L: 3312 D: 7515
https://chess.swehosting.se/test/3118/
```
LTC:
```
ELO   | 7.70 +- 4.28 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 11740 W: 2860 L: 2600 D: 6280
https://chess.swehosting.se/test/3124/
```