### PR TITLE
Decrease Singular Extension Margin.

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -1122,7 +1122,7 @@ impl Board {
 
     /// The reduced beta margin for Singular Extension.
     fn singularity_margin(tt_value: i32, depth: Depth) -> i32 {
-        (tt_value - depth.round()).max(-MATE_SCORE)
+        (tt_value - (depth * 3 / 4).round()).max(-MATE_SCORE)
     }
 
     /// Produce extensions when a move is singular - that is, if it is a move that is


### PR DESCRIPTION
look at me and tell me this isn't peak engine-dev.
```
ELO   | 1.50 +- 2.06 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 0.84 (-2.25, 2.89) [0.00, 3.00]
GAMES | N: 50404 W: 11739 L: 11521 D: 27144
```