### PR TITLE
New non-bucketed 1024x2 network.

### DIFF
--- a/src/nnue/network.rs
+++ b/src/nnue/network.rs
@@ -146,7 +146,6 @@ impl NNUEParams {
     }
 
     pub fn select_feature_weights(&self, bucket: usize) -> &Align64<[i16; INPUT * LAYER_1_SIZE]> {
-        // #[cfg(not(feature = "relnet"))]
         // {
         //     let start = bucket * INPUT * LAYER_1_SIZE;
         //     let end = start + INPUT * LAYER_1_SIZE;
@@ -164,7 +163,6 @@ impl NNUEParams {
         //         &*ptr.cast()
         //     }
         // }
-        // #[cfg(feature = "relnet")]
         &self.feature_weights
     }
 }

--- a/src/nnue/network.rs
+++ b/src/nnue/network.rs
@@ -23,11 +23,8 @@ const CR_MAX: i16 = 255;
 /// a small difference in evaluation.
 const SCALE: i32 = 400;
 /// The size of one-half of the hidden layer of the network.
-pub const LAYER_1_SIZE: usize = 768;
+pub const LAYER_1_SIZE: usize = 1024;
 /// The number of buckets in the feature transformer.
-#[cfg(not(feature = "relnet"))]
-pub const BUCKETS: usize = 64;
-#[cfg(feature = "relnet")]
 pub const BUCKETS: usize = 1;
 
 const QA: i32 = 255;
@@ -149,25 +146,25 @@ impl NNUEParams {
     }
 
     pub fn select_feature_weights(&self, bucket: usize) -> &Align64<[i16; INPUT * LAYER_1_SIZE]> {
-        #[cfg(not(feature = "relnet"))]
-        {
-            let start = bucket * INPUT * LAYER_1_SIZE;
-            let end = start + INPUT * LAYER_1_SIZE;
-            let slice = &self.feature_weights[start..end];
-            // SAFETY: The resulting slice is indeed INPUT * LAYER_1_SIZE long,
-            // and we check that the slice is aligned to 64 bytes.
-            // additionally, we're generating the reference from our own data,
-            // so we know that the lifetime is valid.
-            unsafe {
-                // don't immediately cast to Align64, as we want to check the alignment first.
-                let ptr = slice.as_ptr();
-                assert_eq!(ptr.align_offset(64), 0);
-                // alignments are sensible, so we can safely cast.
-                #[allow(clippy::cast_ptr_alignment)]
-                &*ptr.cast()
-            }
-        }
-        #[cfg(feature = "relnet")]
+        // #[cfg(not(feature = "relnet"))]
+        // {
+        //     let start = bucket * INPUT * LAYER_1_SIZE;
+        //     let end = start + INPUT * LAYER_1_SIZE;
+        //     let slice = &self.feature_weights[start..end];
+        //     // SAFETY: The resulting slice is indeed INPUT * LAYER_1_SIZE long,
+        //     // and we check that the slice is aligned to 64 bytes.
+        //     // additionally, we're generating the reference from our own data,
+        //     // so we know that the lifetime is valid.
+        //     unsafe {
+        //         // don't immediately cast to Align64, as we want to check the alignment first.
+        //         let ptr = slice.as_ptr();
+        //         assert_eq!(ptr.align_offset(64), 0);
+        //         // alignments are sensible, so we can safely cast.
+        //         #[allow(clippy::cast_ptr_alignment)]
+        //         &*ptr.cast()
+        //     }
+        // }
+        // #[cfg(feature = "relnet")]
         &self.feature_weights
     }
 }


### PR DESCRIPTION
epoch 11 net passed STC:
```
ELO   | 10.80 +- 5.46 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
GAMES | N: 8304 W: 2353 L: 2095 D: 3856
https://chess.swehosting.se/test/3723/
```
and LTC:
```
ELO   | 7.66 +- 4.41 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
GAMES | N: 11892 W: 3108 L: 2846 D: 5938
https://chess.swehosting.se/test/3728/
```
then epoch 15 passed vs. epoch 11 at STC:
```
ELO   | 5.33 +- 3.49 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 3.00]
GAMES | N: 18256 W: 4529 L: 4249 D: 9478
https://chess.swehosting.se/test/3750/
```