### PR TITLE
Make aspiration windows move more smoothly.

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -1525,12 +1525,12 @@ impl AspirationWindow {
         Self { alpha: -INFINITY, beta: INFINITY, midpoint: 0, alpha_fails: 0, beta_fails: 0 }
     }
 
-    pub fn around_value(last_score: i32, depth: Depth) -> Self {
-        if is_game_theoretic_score(last_score) {
+    pub fn around_value(value: i32, depth: Depth) -> Self {
+        if is_game_theoretic_score(value) {
             // for mates / tbwins we expect a lot of fluctuation, so aspiration
             // windows are not useful.
             Self {
-                midpoint: last_score,
+                midpoint: value,
                 alpha: -INFINITY,
                 beta: INFINITY,
                 alpha_fails: 0,
@@ -1538,9 +1538,9 @@ impl AspirationWindow {
             }
         } else {
             Self {
-                midpoint: last_score,
-                alpha: last_score - asp_window(depth),
-                beta: last_score + asp_window(depth),
+                midpoint: value,
+                alpha: value - asp_window(depth),
+                beta: value + asp_window(depth),
                 alpha_fails: 0,
                 beta_fails: 0,
             }


### PR DESCRIPTION
```
ELO   | 2.35 +- 1.90 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 3.00]
GAMES | N: 60608 W: 14500 L: 14090 D: 32018
https://chess.swehosting.se/test/3901/
```
Makes each successive aspiration window use a running fast-updating weighted average of the previous evals, rather than only the value of the immediately prior ID iteration.