### PR TITLE
Allow LMR to reduce winning captures.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,3 +32,7 @@ release:
 
 datagen:
 	cargo rustc --release --features syzygy,bindgen,datagen -- -C target-cpu=native
+
+bench:
+	cargo rustc --release -- -C target-cpu=native --emit link=$(NAME)
+	target/release/$(NAME) bench

--- a/src/search.rs
+++ b/src/search.rs
@@ -994,8 +994,7 @@ impl Board {
                 score = -self.full_search::<PV, NNUE>(tt, l_pv, info, t, new_depth, -beta, -alpha);
             } else {
                 // calculation of LMR stuff
-                let r = if (is_quiet || !is_winning_capture)
-                    && depth >= Depth::new(3)
+                let r = if depth >= Depth::new(3)
                     && moves_made >= (2 + usize::from(PV))
                 {
                     let mut r = info.lm_table.lm_reduction(depth, moves_made);
@@ -1013,6 +1012,9 @@ impl Board {
                         } else if history < i32::from(-MAX_HISTORY) / 2 {
                             r += 1;
                         }
+                    } else if is_winning_capture {
+                        // reduce winning captures less
+                        r -= 1;
                     }
                     Depth::new(r).clamp(ONE_PLY, depth - 1)
                 } else {


### PR DESCRIPTION
```
ELO   | 2.81 +- 2.22 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
GAMES | N: 44192 W: 10602 L: 10245 D: 23345
https://chess.swehosting.se/test/4036/
```