### PR TITLE
Do TT-reductions in predicted Cut Nodes.

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -756,6 +756,10 @@ impl Board {
 
         let mut tt_move = tt_hit.map_or(Move::NULL, |hit| hit.tt_move);
 
+        if cut_node && depth >= TT_REDUCTION_DEPTH * 2 && tt_move.is_null() {
+            depth -= 1;
+        }
+
         let see_table = [
             info.search_params.see_tactical_margin * depth.squared(),
             info.search_params.see_quiet_margin * depth.round(),


### PR DESCRIPTION
```
ELO   | 2.97 +- 2.31 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 3.00]
GAMES | N: 40912 W: 9844 L: 9494 D: 21574
https://chess.swehosting.se/test/4344/
```