### PR TITLE
Reduce only quiets using !PV

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -965,7 +965,6 @@ impl Board {
                 // calculation of LMR stuff
                 let r = if depth >= Depth::new(3) && moves_made >= (2 + usize::from(PV)) {
                     let mut r = info.lm_table.lm_reduction(depth, moves_made);
-                    r += i32::from(!PV);
                     if is_quiet {
                         // ordering_score is only robustly a history score
                         // if this is a quiet move. Otherwise, it would be
@@ -980,10 +979,10 @@ impl Board {
                             r += 1;
                         }
 
+                        // reduce more on non-PV nodes
+                        r += i32::from(!PV);
                         // reduce more if it's a cut-node
-                        if cut_node {
-                            r += 1;
-                        }
+                        r += i32::from(cut_node);
                     } else if is_winning_capture {
                         // reduce winning captures less
                         r -= 1;


### PR DESCRIPTION
```
ELO   | 4.17 +- 2.96 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 3.00]
GAMES | N: 24928 W: 6055 L: 5756 D: 13117
https://chess.swehosting.se/test/4368/
```