### PR TITLE
Boost history adjustment in when static eval is low.

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -1096,7 +1096,10 @@ impl Board {
                 t.insert_countermove(self, best_move);
 
                 let moves_to_adjust = quiets_tried.as_slice();
-                self.update_quiet_history(t, moves_to_adjust, best_move, depth);
+                // this heuristic is on the whole unmotivated, beyond mere empiricism.
+                // perhaps it's really important to know which quiet moves are good in "bad" positions?
+                let history_depth_boost = i32::from(static_eval <= alpha);
+                self.update_quiet_history(t, moves_to_adjust, best_move, depth + history_depth_boost);
             }
 
             // we unconditionally update the tactical history table


### PR DESCRIPTION
```
ELO   | 2.97 +- 2.33 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
GAMES | N: 40320 W: 9678 L: 9333 D: 21309
https://chess.swehosting.se/test/4402/
```