### PR TITLE
New network, ID `artemis`.

### DIFF
--- a/src/nnue/network.rs
+++ b/src/nnue/network.rs
@@ -95,7 +95,7 @@ pub static NNUE: NNUEParams =
 pub struct NNUEParams {
     pub feature_weights: Align64<[i16; INPUT * LAYER_1_SIZE * BUCKETS]>,
     pub feature_bias: Align64<[i16; LAYER_1_SIZE]>,
-    pub output_weights: Align64<[i8; LAYER_1_SIZE * 2]>,
+    pub output_weights: Align64<[i16; LAYER_1_SIZE * 2]>,
     pub output_bias: i16,
 }
 
@@ -590,7 +590,7 @@ impl<const MIN: i16, const MAX: i16> ActivationFunction for SquaredClippedRelu<M
 fn flatten<F: ActivationFunction>(
     us: &Align64<[i16; LAYER_1_SIZE]>,
     them: &Align64<[i16; LAYER_1_SIZE]>,
-    weights: &Align64<[i8; LAYER_1_SIZE * 2]>,
+    weights: &Align64<[i16; LAYER_1_SIZE * 2]>,
 ) -> i32 {
     let mut sum: i32 = 0;
     for (&i, &w) in us.iter().zip(&weights[..LAYER_1_SIZE]) {


### PR DESCRIPTION
```
ELO   | 4.27 +- 3.04 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
GAMES | N: 24752 W: 6288 L: 5984 D: 12480
https://chess.swehosting.se/test/4601/
```