### PR TITLE
Bugfix for OOB in singular verification

### DIFF
--- a/src/threadlocal.rs
+++ b/src/threadlocal.rs
@@ -13,7 +13,10 @@ pub struct ThreadData {
     pub evals: [i32; MAX_PLY],
     pub excluded: [Move; MAX_PLY],
     pub best_moves: [Move; MAX_PLY],
-    pub double_extensions: [i32; MAX_PLY],
+    // double-extension array is right-padded by one because
+    // singular verification will try to access the next ply
+    // in an edge case.
+    pub double_extensions: [i32; MAX_PLY + 1],
     pub checks: [bool; MAX_PLY],
     pub banned_nmp: u8,
     pub multi_pv_excluded: Vec<Move>,
@@ -44,7 +47,7 @@ impl ThreadData {
             evals: [0; MAX_PLY],
             excluded: [Move::NULL; MAX_PLY],
             best_moves: [Move::NULL; MAX_PLY],
-            double_extensions: [0; MAX_PLY],
+            double_extensions: [0; MAX_PLY + 1],
             checks: [false; MAX_PLY],
             banned_nmp: 0,
             multi_pv_excluded: Vec::new(),


### PR DESCRIPTION
During testing for the TCEC's FRD1, Viridithas had a crash:
```
1435500 >Viridithas 12.0.0-dev(0): position fen rbbkrnnq/pppppppp/8/8/8/8/PPPPPPPP/RBKNQRBN w FAea - 0 1 moves f2f4 f7f5 c2c4 g7g6 e2e4 f5e4 h1g3 c7c6 g3e4 f8e6 e4g5 g8h6 g5e6 d7e6 d2d4 d8e8 g2g3 h6f5 b1f5 g6f5 e1e2 h8f6 f1e1 b7b5 c4c5 b8c7 a2a4 c7a5 e1f1 b5a4 e2c4 a5c7 c4a4 c8d7 g1e3 f8b8 e3d2 d7e8 d1e3 a7a5 d2c3 f6g6 a1a3 g8f8 f1e1 g6h5 a4c2 a5a4 a3a4 a8a4 c2a4 b8d8 d4d5 c6d5 a4a7 d5d4 a7c7 d8d7 c7e5 d4c3 e5c3 f8g8 e3c2 h5h2 b2b4 g8f7 c5c6 d7d6 c6c7 e8d7 c2a3 d7c8 a3c4 h7h5 c4d6 e7d6 e1d1 h5h4 g3h4 h2f4 c1c2 d6d5 h4h5 f4g5 c2b3 g5g4 d1a1 g4h5 a1a8 d5d4 c3d3 h5h8 b4b5 h8e8 d3c4 d4d3 c4d3 f7e7
1435500 >Viridithas 12.0.0-dev(0): go wtime 599787 btime 36024441 winc 3000 binc 1000
1435567 <Viridithas 12.0.0-dev(0): info score cp 31456 wdl 1000 0 0 depth 23 seldepth 25 nodes 407824 time 50 nps 8109860 hashfull 920 tbhits 9458 pv d3d8 e8d8 c7d8q e7d8 b5b6 d8d7 a8a7 d7d8 b6b7 f5f4 b7c8q d8c8 
1435567 <Viridithas 12.0.0-dev(0): info score cp 31456 wdl 1000 0 0 depth 24 seldepth 25 nodes 460515 time 52 nps 8848239 hashfull 920 tbhits 11678 pv d3d8 e8d8 c7d8q e7d8 b5b6 d8d7 a8a7 d7d8 b6b7 f5f4 b7c8q d8c8 
1435568 <Viridithas 12.0.0-dev(0): info score cp 31456 wdl 1000 0 0 depth 25 seldepth 25 nodes 482500 time 52 nps 9119540 hashfull 920 tbhits 12873 pv d3d8 e8d8 c7d8q e7d8 b5b6 d8d7 a8a7 d7d8 b6b7 f5f4 b7c8q d8c8 
1435572 <Viridithas 12.0.0-dev(0): info score cp 31456 wdl 1000 0 0 depth 26 seldepth 31 nodes 603569 time 56 nps 10748403 hashfull 920 tbhits 17795 pv d3d8 e8d8 c7d8q e7d8 b5b6 d8d7 a8a7 d7d8 b6b7 f5f4 b7c8q d8c8 
1435573 <Viridithas 12.0.0-dev(0): info score cp 31456 wdl 1000 0 0 depth 27 seldepth 29 nodes 659596 time 57 nps 11460207 hashfull 920 tbhits 20254 pv d3d8 e8d8 c7d8q e7d8 b5b6 d8d7 a8a7 d7d8 b6b7 f5f4 b7c8q d8c8 
1435575 <Viridithas 12.0.0-dev(0): info score cp 31456 wdl 1000 0 0 depth 28 seldepth 31 nodes 742334 time 59 nps 12537137 hashfull 920 tbhits 23105 pv d3d8 e8d8 c7d8q e7d8 b5b6 d8d7 a8a7 d7d8 b6b7 f5f4 b7c8q d8c8 
1435577 <Viridithas 12.0.0-dev(0): info score cp 31456 wdl 1000 0 0 depth 29 seldepth 35 nodes 865219 time 61 nps 13981629 hashfull 920 tbhits 28106 pv d3d8 e8d8 c7d8q e7d8 b5b6 d8d7 a8a7 d7d8 b6b7 f5f4 b7c8q d8c8 
1435579 <Viridithas 12.0.0-dev(0): info score cp 31456 wdl 1000 0 0 depth 30 seldepth 31 nodes 919474 time 63 nps 14437547 hashfull 920 tbhits 30246 pv d3d8 e8d8 c7d8q e7d8 b5b6 d8d7 a8a7 d7d8 b6b7 f5f4 b7c8q d8c8 
1435582 <Viridithas 12.0.0-dev(0): info score cp 31456 wdl 1000 0 0 depth 31 seldepth 43 nodes 1045658 time 66 nps 15733787 hashfull 920 tbhits 34166 pv d3d8 e8d8 c7d8q e7d8 b5b6 d8d7 a8a7 d7d8 b6b7 f5f4 b7c8q d8c8 
1436156 <Viridithas 12.0.0-dev(0): info score cp 31457 wdl 1000 0 0 depth 32 seldepth 67 nodes 33131438 time 639 nps 51817445 hashfull 920 tbhits 613276 pv d3d8 e8d8 c7d8q e7d8 b5b6 d8d7 a8a7 d7d8 b6b7 c8b7 
1436158 <Viridithas 12.0.0-dev(0): info score cp 31457 wdl 1000 0 0 depth 33 seldepth 16 nodes 33218091 time 641 nps 51813423 hashfull 920 tbhits 615678 pv d3d8 e8d8 c7d8q e7d8 b5b6 d8d7 a8a7 d7d8 b6b7 c8b7 
1436158 <Viridithas 12.0.0-dev(0): info score cp 31457 wdl 1000 0 0 depth 34 seldepth 16 nodes 33285301 time 642 nps 51814555 hashfull 920 tbhits 617284 pv d3d8 e8d8 c7d8q e7d8 b5b6 d8d7 a8a7 d7d8 b6b7 c8b7 
1436160 <Viridithas 12.0.0-dev(0): info score cp 31457 wdl 1000 0 0 depth 35 seldepth 16 nodes 33359761 time 643 nps 51812911 hashfull 920 tbhits 619128 pv d3d8 e8d8 c7d8q e7d8 b5b6 d8d7 a8a7 d7d8 b6b7 c8b7 
1436167 <Viridithas 12.0.0-dev(0): info score cp 31457 wdl 1000 0 0 depth 36 seldepth 27 nodes 33718129 time 650 nps 51800598 hashfull 920 tbhits 629095 pv d3d8 e8d8 c7d8q e7d8 b5b6 d8d7 a8a7 d7d8 b6b7 c8b7 
1436182 <Viridithas 12.0.0-dev(0): info score cp 31457 wdl 1000 0 0 depth 37 seldepth 37 nodes 34442413 time 665 nps 51755233 hashfull 920 tbhits 648892 pv d3d8 e8d8 c7d8q e7d8 b5b6 d8d7 a8a7 d7d8 b6b7 c8b7 
1436196 <Viridithas 12.0.0-dev(0): info score cp 31457 wdl 1000 0 0 depth 38 seldepth 40 nodes 35155307 time 679 nps 51708421 hashfull 920 tbhits 670167 pv d3d8 e8d8 c7d8q e7d8 b5b6 d8d7 a8a7 d7d8 b6b7 c8b7 
1436231 <Viridithas 12.0.0-dev(0): info score cp 31457 wdl 1000 0 0 depth 39 seldepth 45 nodes 36919104 time 715 nps 51622575 hashfull 920 tbhits 719486 pv d3d8 e8d8 c7d8q e7d8 b5b6 d8d7 a8a7 d7d8 b6b7 c8b7 
1436245 <Viridithas 12.0.0-dev(0): info score cp 31457 wdl 1000 0 0 depth 40 seldepth 43 nodes 37609016 time 728 nps 51615880 hashfull 920 tbhits 739916 pv d3d8 e8d8 c7d8q e7d8 b5b6 d8d7 a8a7 d7d8 b6b7 c8b7 
1436253 <Viridithas 12.0.0-dev(0): info score cp 31457 wdl 1000 0 0 depth 41 seldepth 31 nodes 38034175 time 736 nps 51614281 hashfull 920 tbhits 751293 pv d3d8 e8d8 c7d8q e7d8 b5b6 d8d7 a8a7 d7d8 b6b7 c8b7 
1436343 <Viridithas 12.0.0-dev(0): info score cp 31457 wdl 1000 0 0 depth 42 seldepth 48 nodes 42444069 time 826 nps 51326042 hashfull 920 tbhits 912234 pv d3d8 e8d8 c7d8q e7d8 b5b6 d8d7 a8a7 d7d8 b6b7 c8b7 
1436434 <Viridithas 12.0.0-dev(0): info score cp 31457 wdl 1000 0 0 depth 43 seldepth 43 nodes 46897680 time 918 nps 51067537 hashfull 920 tbhits 1084864 pv d3d8 e8d8 c7d8q e7d8 b5b6 d8d7 a8a7 d7d8 b6b7 c8b7 
Terminating process of engine Viridithas 12.0.0-dev(0)
1439020 >Stockfish_15_10M(1): quit
Finished game 23 (Viridithas 12.0.0-dev vs Stockfish_15_10M): 0-1 {White disconnects}
```
stderr:
```
thread '<unnamed>' panicked at 'index out of bounds: the len is 128 but the index is 128', src/search.rs:1210:59
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
Turns out this was because singular verification can read the double-extensions table one-past the MAX_PLY depth. To fix this, I just added an extra 1 element of padding to that table.
It's clear how this bug can crop up from looking at the singular verification code:
```rust
/// Produce extensions when a move is singular - that is, if it is a move that is
/// significantly better than the rest of the moves in a position.
pub fn singularity<const PV: bool, const NNUE: bool>(
    &mut self,
    tt: TTView,
    info: &mut SearchInfo,
    t: &mut ThreadData,
    m: Move,
    tt_value: i32,
    alpha: i32,
    beta: i32,
    depth: Depth,
    mp: &mut MainMovePicker,
    cut_node: bool,
) -> Depth {
    let mut lpv = PVariation::default();
    let r_beta = Self::singularity_margin(tt_value, depth);
    let r_depth = (depth - 1) / 2;
    // undo the singular move so we can search the position that it exists in.
    self.unmake_move::<NNUE>(t, info);
    t.excluded[self.height()] = m;
    let value =
        self.zw_search::<NNUE>(tt, &mut lpv, info, t, r_depth, r_beta - 1, r_beta, cut_node);
    t.excluded[self.height()] = Move::NULL;
    if value >= r_beta && r_beta >= beta {
        mp.stage = Stage::Done; // multicut!!
    } else {
        // re-make the singular move.
        self.make_move::<NNUE>(m, t, info);
    }

    //                                                          BUG HERE vvvvvvvvvvvvvvv
    let double_extend = !PV && value < r_beta - 15 && t.double_extensions[self.height()] <= 6;

    match () {
        () if double_extend => ONE_PLY * 2, // double-extend if we failed low by a lot (the move is very singular)
        () if value < r_beta => ONE_PLY,    // singular extension
        () if tt_value >= beta => -ONE_PLY, // somewhat multi-cut-y
        () if tt_value <= alpha => -ONE_PLY, // tt_value <= alpha is from Weiss (https://github.com/TerjeKir/weiss/compare/2a7b4ed0...effa8349/)
        () => ZERO_PLY,                      // no extension
    }
}
```