### PR TITLE
weird mean-value trick

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -696,7 +696,7 @@ impl Board {
             if depth <= info.search_params.rfp_depth
                 && static_eval - Self::rfp_margin(info, depth, improving) > beta
             {
-                return static_eval;
+                return (static_eval + beta) / 2;
             }
 
             let last_move_was_null = self.last_move_was_nullmove();


### PR DESCRIPTION
```
ELO   | 2.13 +- 1.73 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
GAMES | N: 73616 W: 17713 L: 17262 D: 38641
https://chess.swehosting.se/test/5045/
```