### PR TITLE
New network, ID `signalis`

### DIFF
--- a/scripts/bench-against.sh
+++ b/scripts/bench-against.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-nice -n 10 cutechess-cli -engine cmd=target/release/viridithas stderr=regteststderr.txt -engine cmd=$1 -each timemargin=400 proto=uci tc=8+0.08 option.Hash=16 -rounds 2500 -concurrency 60 -openings file=../uhobook.pgn order=random format=pgn -repeat -games 2 -pgnout stctests.pgn -event STC_REGRESSION_TEST
+nice -n 10 cutechess-cli -engine cmd=~/personal/viridithas/target/release/viridithas -engine cmd=$1 -each timemargin=400 proto=uci tc=8+0.08 option.Hash=16 -rounds 2500 -concurrency 12 -openings file=book.epd order=random format=epd -repeat -games 2 -pgnout stctests.pgn -event STC_REGRESSION_TEST
 echo "Test done at 8s+0.08s"

--- a/src/board.rs
+++ b/src/board.rs
@@ -1517,14 +1517,6 @@ impl Board {
             if before == after {
                 PovUpdate::BOTH
             } else {
-                // if the bucket changed, save the old acc to the bucket acc cache:
-                t.nnue.save_accumulator_for_position(
-                    colour,
-                    old_white_king,
-                    old_black_king,
-                    pre_move_board_state,
-                );
-
                 // refresh the half of the nnue acc that changed bucket:
                 let refresh = PovUpdate::colour(colour);
                 t.nnue.push_fresh_acc(self, refresh);

--- a/src/board.rs
+++ b/src/board.rs
@@ -1519,6 +1519,7 @@ impl Board {
             } else {
                 // if the bucket changed, save the old acc to the bucket acc cache:
                 t.nnue.save_accumulator_for_position(
+                    colour,
                     old_white_king,
                     old_black_king,
                     pre_move_board_state,

--- a/src/board/evaluation.rs
+++ b/src/board/evaluation.rs
@@ -342,7 +342,7 @@ impl Board {
         let white_pawns = self.pieces.pawns::<true>();
         let black_pawns = self.pieces.pawns::<false>();
 
-        for white_pawn_loc in white_pawns.iter() {
+        for white_pawn_loc in white_pawns {
             if (ISOLATED_BB[white_pawn_loc.index()] & white_pawns).is_empty() {
                 w_score -= i.eval_params.isolated_pawn_malus;
             }
@@ -353,7 +353,7 @@ impl Board {
             }
         }
 
-        for black_pawn_loc in black_pawns.iter() {
+        for black_pawn_loc in black_pawns {
             if (ISOLATED_BB[black_pawn_loc.index()] & black_pawns).is_empty() {
                 b_score -= i.eval_params.isolated_pawn_malus;
             }
@@ -394,7 +394,7 @@ impl Board {
 
     fn rook_open_file_term(&self, i: &SearchInfo) -> S {
         let mut score = S(0, 0);
-        for rook_sq in self.pieces.rooks::<true>().iter() {
+        for rook_sq in self.pieces.rooks::<true>() {
             let file = rook_sq.file();
             if self.is_file_open(file) {
                 score += i.eval_params.rook_open_file_bonus;
@@ -402,7 +402,7 @@ impl Board {
                 score += i.eval_params.rook_half_open_file_bonus;
             }
         }
-        for rook_sq in self.pieces.rooks::<false>().iter() {
+        for rook_sq in self.pieces.rooks::<false>() {
             let file = rook_sq.file();
             if self.is_file_open(file) {
                 score -= i.eval_params.rook_open_file_bonus;
@@ -415,7 +415,7 @@ impl Board {
 
     fn queen_open_file_term(&self, i: &SearchInfo) -> S {
         let mut score = S(0, 0);
-        for queen_sq in self.pieces.queens::<true>().iter() {
+        for queen_sq in self.pieces.queens::<true>() {
             let file = queen_sq.file();
             if self.is_file_open(file) {
                 score += i.eval_params.queen_open_file_bonus;
@@ -423,7 +423,7 @@ impl Board {
                 score += i.eval_params.queen_half_open_file_bonus;
             }
         }
-        for queen_sq in self.pieces.queens::<false>().iter() {
+        for queen_sq in self.pieces.queens::<false>() {
             let file = queen_sq.file();
             if self.is_file_open(file) {
                 score -= i.eval_params.queen_open_file_bonus;
@@ -472,7 +472,7 @@ impl Board {
         let safe_white_moves = !black_pawn_attacks;
         let safe_black_moves = !white_pawn_attacks;
         let blockers = self.pieces.occupied();
-        for knight_sq in self.pieces.knights::<true>().iter() {
+        for knight_sq in self.pieces.knights::<true>() {
             let attacks = bitboards::knight_attacks(knight_sq);
             // kingsafety
             let attacks_on_black_king = attacks & black_king_area;
@@ -489,7 +489,7 @@ impl Board {
             let attacks = attacks.count() as usize;
             mob_score += i.eval_params.knight_mobility_bonus[attacks];
         }
-        for knight_sq in self.pieces.knights::<false>().iter() {
+        for knight_sq in self.pieces.knights::<false>() {
             let attacks = bitboards::knight_attacks(knight_sq);
             // kingsafety
             let attacks_on_white_king = attacks & white_king_area;
@@ -506,7 +506,7 @@ impl Board {
             let attacks = attacks.count() as usize;
             mob_score -= i.eval_params.knight_mobility_bonus[attacks];
         }
-        for bishop_sq in self.pieces.bishops::<true>().iter() {
+        for bishop_sq in self.pieces.bishops::<true>() {
             let attacks = bitboards::bishop_attacks(bishop_sq, blockers);
             // kingsafety
             let attacks_on_black_king = attacks & black_king_area;
@@ -523,7 +523,7 @@ impl Board {
             let attacks = attacks.count() as usize;
             mob_score += i.eval_params.bishop_mobility_bonus[attacks];
         }
-        for bishop_sq in self.pieces.bishops::<false>().iter() {
+        for bishop_sq in self.pieces.bishops::<false>() {
             let attacks = bitboards::bishop_attacks(bishop_sq, blockers);
             // kingsafety
             let attacks_on_white_king = attacks & white_king_area;
@@ -540,7 +540,7 @@ impl Board {
             let attacks = attacks.count() as usize;
             mob_score -= i.eval_params.bishop_mobility_bonus[attacks];
         }
-        for rook_sq in self.pieces.rooks::<true>().iter() {
+        for rook_sq in self.pieces.rooks::<true>() {
             let attacks = bitboards::rook_attacks(rook_sq, blockers);
             // kingsafety
             let attacks_on_black_king = attacks & black_king_area;
@@ -554,7 +554,7 @@ impl Board {
             let attacks = attacks.count() as usize;
             mob_score += i.eval_params.rook_mobility_bonus[attacks];
         }
-        for rook_sq in self.pieces.rooks::<false>().iter() {
+        for rook_sq in self.pieces.rooks::<false>() {
             let attacks = bitboards::rook_attacks(rook_sq, blockers);
             // kingsafety
             let attacks_on_white_king = attacks & white_king_area;
@@ -568,7 +568,7 @@ impl Board {
             let attacks = attacks.count() as usize;
             mob_score -= i.eval_params.rook_mobility_bonus[attacks];
         }
-        for queen_sq in self.pieces.queens::<true>().iter() {
+        for queen_sq in self.pieces.queens::<true>() {
             let attacks = bitboards::queen_attacks(queen_sq, blockers);
             // kingsafety
             let attacks_on_black_king = attacks & black_king_area;
@@ -582,7 +582,7 @@ impl Board {
             let attacks = attacks.count() as usize;
             mob_score += i.eval_params.queen_mobility_bonus[attacks];
         }
-        for queen_sq in self.pieces.queens::<false>().iter() {
+        for queen_sq in self.pieces.queens::<false>() {
             let attacks = bitboards::queen_attacks(queen_sq, blockers);
             // kingsafety
             let attacks_on_white_king = attacks & white_king_area;

--- a/src/board/movegen.rs
+++ b/src/board/movegen.rs
@@ -104,26 +104,26 @@ impl Board {
             their_pieces.north_west_one() & our_pawns
         };
         let promo_rank = if IS_WHITE { SquareSet::RANK_7 } else { SquareSet::RANK_2 };
-        for from in (attacking_west & !promo_rank).iter() {
+        for from in attacking_west & !promo_rank {
             let to = if IS_WHITE { from.add(7) } else { from.sub(9) };
             move_list.push::<true>(Move::new(from, to));
         }
-        for from in (attacking_east & !promo_rank).iter() {
+        for from in attacking_east & !promo_rank {
             let to = if IS_WHITE { from.add(9) } else { from.sub(7) };
             move_list.push::<true>(Move::new(from, to));
         }
         if QS {
             // in quiescence search, we only generate promotions to queen.
-            for from in (attacking_west & promo_rank).iter() {
+            for from in attacking_west & promo_rank {
                 let to = if IS_WHITE { from.add(7) } else { from.sub(9) };
                 move_list.push::<true>(Move::new_with_promo(from, to, PieceType::QUEEN));
             }
-            for from in (attacking_east & promo_rank).iter() {
+            for from in attacking_east & promo_rank {
                 let to = if IS_WHITE { from.add(9) } else { from.sub(7) };
                 move_list.push::<true>(Move::new_with_promo(from, to, PieceType::QUEEN));
             }
         } else {
-            for from in (attacking_west & promo_rank).iter() {
+            for from in attacking_west & promo_rank {
                 let to = if IS_WHITE { from.add(7) } else { from.sub(9) };
                 for promo in
                     [PieceType::QUEEN, PieceType::ROOK, PieceType::BISHOP, PieceType::KNIGHT]
@@ -131,7 +131,7 @@ impl Board {
                     move_list.push::<true>(Move::new_with_promo(from, to, promo));
                 }
             }
-            for from in (attacking_east & promo_rank).iter() {
+            for from in attacking_east & promo_rank {
                 let to = if IS_WHITE { from.add(9) } else { from.sub(7) };
                 for promo in
                     [PieceType::QUEEN, PieceType::ROOK, PieceType::BISHOP, PieceType::KNIGHT]
@@ -180,15 +180,15 @@ impl Board {
         let pushable_pawns = our_pawns & shifted_empty_squares;
         let double_pushable_pawns = pushable_pawns & double_shifted_empty_squares & start_rank;
         let promoting_pawns = pushable_pawns & promo_rank;
-        for sq in (pushable_pawns & !promoting_pawns).iter() {
+        for sq in pushable_pawns & !promoting_pawns {
             let to = if IS_WHITE { sq.add(8) } else { sq.sub(8) };
             move_list.push::<false>(Move::new(sq, to));
         }
-        for sq in double_pushable_pawns.iter() {
+        for sq in double_pushable_pawns {
             let to = if IS_WHITE { sq.add(16) } else { sq.sub(16) };
             move_list.push::<false>(Move::new(sq, to));
         }
-        for sq in promoting_pawns.iter() {
+        for sq in promoting_pawns {
             let to = if IS_WHITE { sq.add(8) } else { sq.sub(8) };
             for promo in [PieceType::QUEEN, PieceType::KNIGHT, PieceType::ROOK, PieceType::BISHOP] {
                 move_list.push::<true>(Move::new_with_promo(sq, to, promo));
@@ -206,7 +206,7 @@ impl Board {
         let our_pawns = self.pieces.pawns::<IS_WHITE>();
         let pushable_pawns = our_pawns & shifted_empty_squares;
         let promoting_pawns = pushable_pawns & promo_rank;
-        for sq in promoting_pawns.iter() {
+        for sq in promoting_pawns {
             let to = if IS_WHITE { sq.add(8) } else { sq.sub(8) };
             if QS {
                 // in quiescence search, we only generate promotions to queen.
@@ -243,24 +243,24 @@ impl Board {
         let our_knights = self.pieces.knights::<IS_WHITE>();
         let their_pieces = self.pieces.their_pieces::<IS_WHITE>();
         let freespace = self.pieces.empty();
-        for sq in our_knights.iter() {
+        for sq in our_knights {
             let moves = bitboards::knight_attacks(sq);
-            for to in (moves & their_pieces).iter() {
+            for to in moves & their_pieces {
                 move_list.push::<true>(Move::new(sq, to));
             }
-            for to in (moves & freespace).iter() {
+            for to in moves & freespace {
                 move_list.push::<false>(Move::new(sq, to));
             }
         }
 
         // kings
         let our_king = self.pieces.king::<IS_WHITE>();
-        for sq in our_king.iter() {
+        for sq in our_king {
             let moves = bitboards::king_attacks(sq);
-            for to in (moves & their_pieces).iter() {
+            for to in moves & their_pieces {
                 move_list.push::<true>(Move::new(sq, to));
             }
-            for to in (moves & freespace).iter() {
+            for to in moves & freespace {
                 move_list.push::<false>(Move::new(sq, to));
             }
         }
@@ -268,24 +268,24 @@ impl Board {
         // bishops and queens
         let our_diagonal_sliders = self.pieces.bishopqueen::<IS_WHITE>();
         let blockers = self.pieces.occupied();
-        for sq in our_diagonal_sliders.iter() {
+        for sq in our_diagonal_sliders {
             let moves = bitboards::bishop_attacks(sq, blockers);
-            for to in (moves & their_pieces).iter() {
+            for to in moves & their_pieces {
                 move_list.push::<true>(Move::new(sq, to));
             }
-            for to in (moves & freespace).iter() {
+            for to in moves & freespace {
                 move_list.push::<false>(Move::new(sq, to));
             }
         }
 
         // rooks and queens
         let our_orthogonal_sliders = self.pieces.rookqueen::<IS_WHITE>();
-        for sq in our_orthogonal_sliders.iter() {
+        for sq in our_orthogonal_sliders {
             let moves = bitboards::rook_attacks(sq, blockers);
-            for to in (moves & their_pieces).iter() {
+            for to in moves & their_pieces {
                 move_list.push::<true>(Move::new(sq, to));
             }
-            for to in (moves & freespace).iter() {
+            for to in moves & freespace {
                 move_list.push::<false>(Move::new(sq, to));
             }
         }
@@ -320,18 +320,18 @@ impl Board {
         // knights
         let our_knights = self.pieces.knights::<IS_WHITE>();
         let their_pieces = self.pieces.their_pieces::<IS_WHITE>();
-        for sq in our_knights.iter() {
+        for sq in our_knights {
             let moves = bitboards::knight_attacks(sq);
-            for to in (moves & their_pieces).iter() {
+            for to in moves & their_pieces {
                 move_list.push::<true>(Move::new(sq, to));
             }
         }
 
         // kings
         let our_king = self.pieces.king::<IS_WHITE>();
-        for sq in our_king.iter() {
+        for sq in our_king {
             let moves = bitboards::king_attacks(sq);
-            for to in (moves & their_pieces).iter() {
+            for to in moves & their_pieces {
                 move_list.push::<true>(Move::new(sq, to));
             }
         }
@@ -339,9 +339,9 @@ impl Board {
         // bishops and queens
         let our_diagonal_sliders = self.pieces.bishopqueen::<IS_WHITE>();
         let blockers = self.pieces.occupied();
-        for sq in our_diagonal_sliders.iter() {
+        for sq in our_diagonal_sliders {
             let moves = bitboards::bishop_attacks(sq, blockers);
-            for to in (moves & their_pieces).iter() {
+            for to in moves & their_pieces {
                 move_list.push::<true>(Move::new(sq, to));
             }
         }
@@ -349,9 +349,9 @@ impl Board {
         // rooks and queens
         let our_orthogonal_sliders = self.pieces.rookqueen::<IS_WHITE>();
         let blockers = self.pieces.occupied();
-        for sq in our_orthogonal_sliders.iter() {
+        for sq in our_orthogonal_sliders {
             let moves = bitboards::rook_attacks(sq, blockers);
-            for to in (moves & their_pieces).iter() {
+            for to in moves & their_pieces {
                 move_list.push::<true>(Move::new(sq, to));
             }
         }
@@ -506,11 +506,11 @@ impl Board {
         let pushable_pawns = our_pawns & shifted_empty_squares;
         let double_pushable_pawns = pushable_pawns & double_shifted_empty_squares & start_rank;
         let promoting_pawns = pushable_pawns & promo_rank;
-        for sq in (pushable_pawns & !promoting_pawns).iter() {
+        for sq in pushable_pawns & !promoting_pawns {
             let to = if IS_WHITE { sq.add(8) } else { sq.sub(8) };
             move_list.push::<false>(Move::new(sq, to));
         }
-        for sq in double_pushable_pawns.iter() {
+        for sq in double_pushable_pawns {
             let to = if IS_WHITE { sq.add(16) } else { sq.sub(16) };
             move_list.push::<false>(Move::new(sq, to));
         }
@@ -523,9 +523,9 @@ impl Board {
         // knights
         let our_knights = self.pieces.knights::<IS_WHITE>();
         let blockers = self.pieces.occupied();
-        for sq in our_knights.iter() {
+        for sq in our_knights {
             let moves = bitboards::knight_attacks(sq);
-            for to in (moves & !blockers).iter() {
+            for to in moves & !blockers {
                 move_list.push::<false>(Move::new(sq, to));
             }
         }
@@ -533,9 +533,9 @@ impl Board {
         // kings
         let our_king = self.pieces.king::<IS_WHITE>();
         let blockers = self.pieces.occupied();
-        for sq in our_king.iter() {
+        for sq in our_king {
             let moves = bitboards::king_attacks(sq);
-            for to in (moves & !blockers).iter() {
+            for to in moves & !blockers {
                 move_list.push::<false>(Move::new(sq, to));
             }
         }
@@ -543,9 +543,9 @@ impl Board {
         // bishops and queens
         let our_diagonal_sliders = self.pieces.bishopqueen::<IS_WHITE>();
         let blockers = self.pieces.occupied();
-        for sq in our_diagonal_sliders.iter() {
+        for sq in our_diagonal_sliders {
             let moves = bitboards::bishop_attacks(sq, blockers);
-            for to in (moves & !blockers).iter() {
+            for to in moves & !blockers {
                 move_list.push::<false>(Move::new(sq, to));
             }
         }
@@ -553,9 +553,9 @@ impl Board {
         // rooks and queens
         let our_orthogonal_sliders = self.pieces.rookqueen::<IS_WHITE>();
         let blockers = self.pieces.occupied();
-        for sq in our_orthogonal_sliders.iter() {
+        for sq in our_orthogonal_sliders {
             let moves = bitboards::rook_attacks(sq, blockers);
-            for to in (moves & !blockers).iter() {
+            for to in moves & !blockers {
                 move_list.push::<false>(Move::new(sq, to));
             }
         }

--- a/src/board/movegen/bitboards.rs
+++ b/src/board/movegen/bitboards.rs
@@ -2,9 +2,10 @@ use std::fmt::Display;
 
 use crate::{
     lookups, magic,
+    nnue::network::FeatureUpdate,
     piece::{Colour, Piece, PieceType},
     squareset::SquareSet,
-    util::Square, nnue::network::FeatureUpdate,
+    util::Square,
 };
 
 pub const LIGHT_SQUARE: bool = true;

--- a/src/board/validation.rs
+++ b/src/board/validation.rs
@@ -52,7 +52,7 @@ impl Board {
         // check bitboard / piece array coherency
         for piece in Piece::all() {
             let bb = self.pieces.piece_bb(piece);
-            for sq in bb.iter() {
+            for sq in bb {
                 if self.piece_at(sq) != piece {
                     return Err(format!(
                         "bitboard / piece array coherency corrupt: expected square {} to be '{:?}' but was '{:?}'",

--- a/src/chessmove.rs
+++ b/src/chessmove.rs
@@ -227,8 +227,8 @@ mod tests {
     fn test_all_square_combinations() {
         use super::*;
         use crate::squareset::SquareSet;
-        for from in SquareSet::FULL.iter() {
-            for to in SquareSet::FULL.iter() {
+        for from in SquareSet::FULL {
+            for to in SquareSet::FULL {
                 let m = Move::new(from, to);
                 assert_eq!(m.from(), from);
                 assert_eq!(m.to(), to);

--- a/src/magic.rs
+++ b/src/magic.rs
@@ -472,7 +472,7 @@ static ROOK_MAGICS: [u64; 64] = [
 ];
 
 #[allow(clippy::cast_possible_truncation)]
-pub fn get_bishop_attacks(sq: Square, blockers: SquareSet) -> SquareSet {
+pub fn get_diagonal_attacks(sq: Square, blockers: SquareSet) -> SquareSet {
     let sq = sq.index();
     if sq >= 64 {
         unsafe {
@@ -493,7 +493,7 @@ pub fn get_bishop_attacks(sq: Square, blockers: SquareSet) -> SquareSet {
 }
 
 #[allow(clippy::cast_possible_truncation)]
-pub fn get_rook_attacks(sq: Square, blockers: SquareSet) -> SquareSet {
+pub fn get_orthogonal_attacks(sq: Square, blockers: SquareSet) -> SquareSet {
     let sq = sq.index();
     if sq >= 64 {
         unsafe {

--- a/src/nnue/network.rs
+++ b/src/nnue/network.rs
@@ -460,6 +460,10 @@ impl NNUEState {
         for acc in self.bucket_cache.accs.iter_mut().flatten() {
             acc.init(&NNUE.feature_bias, PovUpdate::BOTH);
         }
+        // initialise all the board states in the bucket cache to the empty board
+        for board_state in self.bucket_cache.board_states.iter_mut().flatten() {
+            *board_state = BitBoard::NULL;
+        }
 
         // refresh the first accumulator
         Self::refresh_accumulators(

--- a/src/nnue/network.rs
+++ b/src/nnue/network.rs
@@ -212,11 +212,9 @@ impl BucketAccumulatorCache {
         let cache_acc = &self.accs[side_we_care_about.index()][bucket];
         // we use the first update to copy over the accumulator, then subsequent updates are done in place.
         let mut first_update_seen = false;
-        // eprintln!("recovering an accumulator from the cache.");
         self.board_states[side_we_care_about.index()][bucket].update_iter(
             board_state,
             |FeatureUpdate { from, to, piece }| {
-                // eprint!("[{feature_update}] ");
                 let pt = piece.piece_type();
                 let c = piece.colour();
                 if first_update_seen {
@@ -249,11 +247,10 @@ impl BucketAccumulatorCache {
                 }
             },
         );
+        // if we didn't see any updates, then we can just copy the accumulator from the cache.
         if !first_update_seen {
-            // eprintln!("no updates seen, copying accumulator from cache.");
             *acc = *cache_acc;
         }
-        // eprintln!();
     }
 }
 

--- a/src/nnue/network.rs
+++ b/src/nnue/network.rs
@@ -98,7 +98,7 @@ impl FeatureUpdate {
         Self { from: sq, to: Square::NO_SQUARE, piece }
     }
 
-    pub const fn _move_piece(from: Square, to: Square, piece: Piece) -> Self {
+    pub const fn move_piece(from: Square, to: Square, piece: Piece) -> Self {
         Self { from, to, piece }
     }
 }

--- a/src/search.rs
+++ b/src/search.rs
@@ -167,7 +167,7 @@ impl Board {
             #[cfg(feature = "stats")]
             println!(
                 "branching factor: {}",
-                (info.nodes as f64).powf(1.0 / thread_headers[0].completed as f64)
+                (info.nodes.get_global() as f64).powf(1.0 / thread_headers[0].completed as f64)
             );
         }
 

--- a/src/squareset.rs
+++ b/src/squareset.rs
@@ -156,6 +156,15 @@ impl SquareSet {
     }
 }
 
+impl IntoIterator for SquareSet {
+    type Item = Square;
+    type IntoIter = BitLoop;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
 impl BitOr for SquareSet {
     type Output = Self;
 


### PR DESCRIPTION
This PR adds
- support for king-bucket inference
- an optimisation for king-bucket inference using accumulator caching ("finny tables")
- a new network, `signalis`, which uses four king buckets and horizontal mirroring.
```
ELO   | 5.47 +- 3.57 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
GAMES | N: 17672 W: 4452 L: 4174 D: 9046
https://chess.swehosting.se/test/5227/
```