### PR TITLE
optimise MoveList allocation, Colour type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,6 +75,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -579,6 +585,7 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 name = "viridithas"
 version = "12.0.0"
 dependencies = [
+ "arrayvec",
  "bindgen",
  "bulletformat",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,10 @@ clap = { version = "4.2.7", features = ["derive"] }
 chrono = "0.4.23"
 ctrlc = "3.2.5"
 bulletformat = "0.1.0"
+arrayvec = "0.7.4"
 
 [profile.release]
 lto = true
 panic = "abort"
 strip = true
+# debug = true

--- a/src/datagen/dataformat/marlinformat.rs
+++ b/src/datagen/dataformat/marlinformat.rs
@@ -64,13 +64,13 @@ impl PackedBoard {
 
             debug_assert_eq!(piece_code & 0b0111, piece_code);
             debug_assert_ne!(piece_code, 0b0111, "we are not using the 0b0111 piece code");
-            pieces.set(i, piece_code | (colour.inner()) << 3);
+            pieces.set(i, piece_code | u8::from(colour.inner()) << 3);
         }
 
         Self {
             occupancy: util::U64Le::new(occupancy.inner()),
             pieces,
-            stm_ep_square: (board.turn().inner()) << 7 | board.ep_sq().inner(),
+            stm_ep_square: u8::from(board.turn().inner()) << 7 | board.ep_sq().inner(),
             halfmove_clock: board.fifty_move_counter(),
             fullmove_number: util::U16Le::new(board.full_move_number().try_into().unwrap()),
             wdl,
@@ -84,7 +84,7 @@ impl PackedBoard {
 
         let mut seen_king = [false; 2];
         for (i, sq) in SquareSet::from_inner(self.occupancy.get()).iter().enumerate() {
-            let colour = Colour::new(self.pieces.get(i) >> 3);
+            let colour = Colour::new(self.pieces.get(i) >> 3 != 0);
             let piece_code = self.pieces.get(i) & 0b0111;
             let piece_type = match piece_code {
                 UNMOVED_ROOK => {
@@ -104,7 +104,7 @@ impl PackedBoard {
         }
 
         *builder.ep_sq_mut() = Square::new(self.stm_ep_square & 0b0111_1111);
-        *builder.turn_mut() = Colour::new(self.stm_ep_square >> 7);
+        *builder.turn_mut() = Colour::new(self.stm_ep_square >> 7 != 0);
         *builder.halfmove_clock_mut() = self.halfmove_clock;
         builder.set_fullmove_clock(self.fullmove_number.get());
 

--- a/src/nnue/network.rs
+++ b/src/nnue/network.rs
@@ -75,11 +75,10 @@ impl PovUpdate {
         Self { white: self.black, black: self.white }
     }
 
-    pub fn colour(colour: Colour) -> Self {
+    pub const fn colour(colour: Colour) -> Self {
         match colour {
             Colour::WHITE => Self { white: true, black: false },
             Colour::BLACK => Self { white: false, black: true },
-            _ => unreachable!(),
         }
     }
 }

--- a/src/perft.rs
+++ b/src/perft.rs
@@ -25,7 +25,7 @@ pub fn perft(pos: &mut Board, depth: usize) -> u64 {
     pos.generate_moves(&mut ml);
 
     let mut count = 0;
-    for &m in ml.iter() {
+    for &m in ml.iter_moves() {
         if !pos.make_move_simple(m) {
             continue;
         }
@@ -50,7 +50,7 @@ pub fn nnue_perft(pos: &mut Board, t: &mut ThreadData, depth: usize) -> u64 {
     pos.generate_moves(&mut ml);
 
     let mut count = 0;
-    for &m in ml.iter() {
+    for &m in ml.iter_moves() {
         if !pos.make_move_nnue(m, t) {
             continue;
         }

--- a/src/piece.rs
+++ b/src/piece.rs
@@ -2,7 +2,7 @@ use std::fmt::{Debug, Display};
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct Colour {
-    v: u8,
+    v: bool,
 }
 
 impl Debug for Colour {
@@ -10,7 +10,6 @@ impl Debug for Colour {
         match *self {
             Self::WHITE => write!(f, "Colour::WHITE"),
             Self::BLACK => write!(f, "Colour::BLACK"),
-            _ => write!(f, "Colour::INVALID({})", self.v),
         }
     }
 }
@@ -20,7 +19,6 @@ impl Display for Colour {
         match *self {
             Self::WHITE => write!(f, "White"),
             Self::BLACK => write!(f, "Black"),
-            _ => write!(f, "?"),
         }
     }
 }
@@ -98,23 +96,22 @@ impl Display for Piece {
 }
 
 impl Colour {
-    pub const WHITE: Self = Self { v: 0 };
-    pub const BLACK: Self = Self { v: 1 };
+    pub const WHITE: Self = Self { v: false };
+    pub const BLACK: Self = Self { v: true };
 
-    pub const fn new(v: u8) -> Self {
-        debug_assert!(v < 2);
+    pub const fn new(v: bool) -> Self {
         Self { v }
     }
 
     pub const fn flip(self) -> Self {
-        Self::new(self.v ^ 1)
+        Self::new(!self.v)
     }
 
     pub const fn index(self) -> usize {
         self.v as usize
     }
 
-    pub const fn inner(self) -> u8 {
+    pub const fn inner(self) -> bool {
         self.v
     }
 
@@ -219,15 +216,15 @@ impl Piece {
     pub const EMPTY: Self = Self { v: 12 };
 
     pub const fn new(colour: Colour, piece_type: PieceType) -> Self {
-        debug_assert!(colour.v < 2);
         debug_assert!(piece_type.v < 7);
-        Self { v: colour.v * 6 + piece_type.v }
+        Self { v: colour.v as u8 * 6 + piece_type.v }
     }
 
     pub const fn colour(self) -> Colour {
-        match self {
-            Self::WP | Self::WN | Self::WB | Self::WR | Self::WQ | Self::WK => Colour::WHITE,
-            _ => Colour::BLACK,
+        if self.v < 6 {
+            Colour::WHITE
+        } else {
+            Colour::BLACK
         }
     }
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -9,6 +9,8 @@ use std::{
     thread,
 };
 
+use arrayvec::ArrayVec;
+
 use crate::{
     board::{
         evaluation::{
@@ -33,7 +35,7 @@ use crate::{
     transpositiontable::{Bound, TTHit, TTView},
     uci,
     util::{
-        depth::Depth, depth::ONE_PLY, depth::ZERO_PLY, StackVec, INFINITY, MAX_DEPTH, VALUE_NONE,
+        depth::Depth, depth::ONE_PLY, depth::ZERO_PLY, INFINITY, MAX_DEPTH, VALUE_NONE,
     },
 };
 
@@ -882,8 +884,8 @@ impl Board {
         let counter_move = t.get_counter_move(self);
         let mut move_picker = MainMovePicker::new(tt_move, killers, counter_move, 0);
 
-        let mut quiets_tried = StackVec::<_, MAX_POSITION_MOVES>::from_default(Move::NULL);
-        let mut tacticals_tried = StackVec::<_, MAX_POSITION_MOVES>::from_default(Move::NULL);
+        let mut quiets_tried = ArrayVec::<_, MAX_POSITION_MOVES>::new();
+        let mut tacticals_tried = ArrayVec::<_, MAX_POSITION_MOVES>::new();
         while let Some(MoveListEntry { mov: m, score: movepick_score }) = move_picker.next(self, t)
         {
             debug_assert!(

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -795,7 +795,7 @@ fn divide_perft(depth: usize, pos: &mut Board) {
     let mut nodes = 0;
     let mut ml = MoveList::new();
     pos.generate_moves(&mut ml);
-    for &m in ml.iter() {
+    for &m in ml.iter_moves() {
         if !pos.make_move_simple(m) {
             continue;
         }

--- a/src/util.rs
+++ b/src/util.rs
@@ -343,26 +343,6 @@ pub enum CheckState {
     Checkmate,
 }
 
-pub struct StackVec<T: Copy, const CAPACITY: usize> {
-    data: [T; CAPACITY],
-    len: usize,
-}
-
-impl<T: Copy, const CAPACITY: usize> StackVec<T, CAPACITY> {
-    pub const fn from_default(default: T) -> Self {
-        Self { data: [default; CAPACITY], len: 0 }
-    }
-
-    pub fn push(&mut self, item: T) {
-        self.data[self.len] = item;
-        self.len += 1;
-    }
-
-    pub fn as_slice(&self) -> &[T] {
-        &self.data[..self.len]
-    }
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CastlingRights {
     pub wk: Square,


### PR DESCRIPTION
```
cosmo@tarski:~/external/EngineTests(master)$ python speedup.py
               master               |           optimisations            |
        mu              sigma       |        mu              sigma       |   Sp(1)/Sp(2)      3*sigma   
------------------------------------+------------------------------------+------------------------------------
       1270957.000             0.000|       1323882.000             0.000|      -3.998 %  +/-  0.000 %
       1225279.000         64598.447|       1311429.500         17610.494|      -6.594 %  +/-  11.015 %
       1224600.000         45693.137|       1301642.000         21034.501|      -5.925 %  +/-  8.528 %
       1220447.500         38221.480|       1285831.250         35984.526|      -5.058 %  +/-  8.693 %
       1216511.800         34250.691|       1287933.200         31515.957|      -5.521 %  +/-  8.144 %
       1216412.667         30635.712|       1286814.167         28321.685|      -5.450 %  +/-  7.303 %
       1214342.143         28497.927|       1280215.571         31196.502|      -5.117 %  +/-  7.171 %
       1214362.625         26384.017|       1282838.125         29819.664|      -5.310 %  +/-  6.838 %
       1214268.778         24681.594|       1282708.556         27896.450|      -5.311 %  +/-  6.397 %
       1214562.000         23288.497|       1281400.500         26624.312|      -5.193 %  +/-  6.134 %
       1216619.727         23123.480|       1285284.091         28352.666|      -5.318 %  +/-  5.950 %
       1214372.417         23381.436|       1285992.250         27144.283|      -5.545 %  +/-  6.146 %
       1213253.385         22746.713|       1282769.308         28468.347|      -5.392 %  +/-  6.113 %
       1210001.929         25012.386|       1282391.429         27388.023|      -5.621 %  +/-  6.408 %
       1209417.467         24208.600|       1278681.333         30049.909|      -5.385 %  +/-  6.757 %
       1206272.188         26556.927|       1279568.312         29246.965|      -5.695 %  +/-  7.515 %
       1207541.412         26240.747|       1280388.353         28519.385|      -5.659 %  +/-  7.290 %
       1208555.667         25818.387|       1281266.944         27917.835|      -5.646 %  +/-  7.074 %
       1208476.579         25093.330|       1282758.316         27899.190|      -5.761 %  +/-  7.037 %
       1209433.700         24796.291|       1284051.650         27764.230|      -5.782 %  +/-  6.856 %
       1210936.952         25131.024|       1283406.952         27222.017|      -5.618 %  +/-  7.055 %
       1211257.955         24571.541|       1284951.091         27535.553|      -5.705 %  +/-  6.995 %
       1209645.000         25222.099|       1282320.000         29714.701|      -5.636 %  +/-  6.907 %
       1208718.000         25082.250|       1283266.417         29429.078|      -5.776 %  +/-  7.065 %
       1210503.720         26127.110|       1285285.040         30526.306|      -5.786 %  +/-  6.917 %
       1211498.846         26097.280|       1286097.269         30194.929|      -5.770 %  +/-  6.782 %
       1212178.444         25832.985|       1285502.852         29769.230|      -5.674 %  +/-  6.819 %
       1213565.071         26390.591|       1287044.500         30330.374|      -5.680 %  +/-  6.692 %
```