### PR TITLE
prefetch before updating a whole bunch of state

### DIFF
--- a/src/board/history.rs
+++ b/src/board/history.rs
@@ -8,7 +8,7 @@ use crate::{
 
 use super::{movegen::MoveListEntry, Board};
 
-impl ThreadData {
+impl ThreadData<'_> {
     /// Update the history counters of a batch of moves.
     pub fn update_history(
         &mut self,

--- a/src/datagen.rs
+++ b/src/datagen.rs
@@ -217,9 +217,9 @@ fn generate_on_thread(
     // so no worries :3
     let mut rng = rand::thread_rng();
     let mut board = Board::default();
-    let mut thread_data = ThreadData::new(0, &board);
     let mut tt = TT::new();
     tt.resize(16 * MEGABYTE);
+    let mut thread_data = ThreadData::new(0, &board, tt.view());
     let stopped = AtomicBool::new(false);
     let time_manager = TimeManager::default_with_limit(match options.limit {
         DataGenLimit::Depth(depth) => SearchLimit::Depth(Depth::new(depth)),

--- a/src/perft.rs
+++ b/src/perft.rs
@@ -128,7 +128,7 @@ mod tests {
     #![allow(unused_imports)]
     use std::sync::atomic::{AtomicBool, AtomicU64};
 
-    use crate::{chessmove::Move, piece::PieceType, util::Square};
+    use crate::{chessmove::Move, piece::PieceType, transpositiontable::TT, util::Square};
 
     #[test]
     fn perft_hard_position() {
@@ -167,7 +167,8 @@ mod tests {
         use super::*;
 
         let mut pos = Board::default();
-        let mut t = ThreadData::new(0, &pos);
+        let tt = TT::new();
+        let mut t = ThreadData::new(0, &pos, tt.view());
         assert_eq!(nnue_perft(&mut pos, &mut t, 1), 20, "got {}", {
             pos.legal_moves().into_iter().map(|m| m.to_string()).collect::<Vec<_>>().join(", ")
         });

--- a/src/searchinfo.rs
+++ b/src/searchinfo.rs
@@ -254,7 +254,7 @@ mod tests {
         let mut info = SearchInfo { time_manager, ..SearchInfo::new(&stopped, &nodes) };
         let mut tt = TT::new();
         tt.resize(MEGABYTE);
-        let mut t = ThreadData::new(0, &position);
+        let mut t = ThreadData::new(0, &position, tt.view());
         let (value, mov) = position.search_position(&mut info, array::from_mut(&mut t), tt.view());
 
         assert!(matches!(position.san(mov).as_deref(), Some("Bxd5+")));
@@ -275,7 +275,7 @@ mod tests {
         let mut info = SearchInfo { time_manager, ..SearchInfo::new(&stopped, &nodes) };
         let mut tt = TT::new();
         tt.resize(MEGABYTE);
-        let mut t = ThreadData::new(0, &position);
+        let mut t = ThreadData::new(0, &position, tt.view());
         let (value, mov) = position.search_position(&mut info, array::from_mut(&mut t), tt.view());
 
         assert!(matches!(position.san(mov).as_deref(), Some("Qxd5")));
@@ -296,7 +296,7 @@ mod tests {
         let mut info = SearchInfo { time_manager, ..SearchInfo::new(&stopped, &nodes) };
         let mut tt = TT::new();
         tt.resize(MEGABYTE);
-        let mut t = ThreadData::new(0, &position);
+        let mut t = ThreadData::new(0, &position, tt.view());
         let (value, mov) = position.search_position(&mut info, array::from_mut(&mut t), tt.view());
 
         assert!(matches!(position.san(mov).as_deref(), Some("Qxd4")));
@@ -317,7 +317,7 @@ mod tests {
         let mut info = SearchInfo { time_manager, ..SearchInfo::new(&stopped, &nodes) };
         let mut tt = TT::new();
         tt.resize(MEGABYTE);
-        let mut t = ThreadData::new(0, &position);
+        let mut t = ThreadData::new(0, &position, tt.view());
         let (value, mov) = position.search_position(&mut info, array::from_mut(&mut t), tt.view());
 
         assert!(matches!(position.san(mov).as_deref(), Some("Bxd4+")));

--- a/src/threadlocal.rs
+++ b/src/threadlocal.rs
@@ -1,15 +1,9 @@
 use crate::{
-    board::Board,
-    chessmove::Move,
-    historytable::{CaptureHistoryTable, DoubleHistoryTable, MoveTable, ThreatsHistoryTable},
-    nnue,
-    piece::Colour,
-    search::pv::PVariation,
-    util::MAX_PLY,
+    board::Board, chessmove::Move, historytable::{CaptureHistoryTable, DoubleHistoryTable, MoveTable, ThreatsHistoryTable}, nnue, piece::Colour, search::pv::PVariation, transpositiontable::TTView, util::MAX_PLY
 };
 
 #[derive(Clone)]
-pub struct ThreadData {
+pub struct ThreadData<'a> {
     pub evals: [i32; MAX_PLY],
     pub excluded: [Move; MAX_PLY],
     pub best_moves: [Move; MAX_PLY],
@@ -37,13 +31,15 @@ pub struct ThreadData {
     pub depth: usize,
 
     pub stm_at_root: Colour,
+
+    pub tt: TTView<'a>,
 }
 
-impl ThreadData {
+impl<'a> ThreadData<'a> {
     const WHITE_BANNED_NMP: u8 = 0b01;
     const BLACK_BANNED_NMP: u8 = 0b10;
 
-    pub fn new(thread_id: usize, board: &Board) -> Self {
+    pub fn new(thread_id: usize, board: &Board, tt: TTView<'a>) -> Self {
         let mut td = Self {
             evals: [0; MAX_PLY],
             excluded: [Move::NULL; MAX_PLY],
@@ -63,6 +59,7 @@ impl ThreadData {
             completed: 0,
             depth: 0,
             stm_at_root: board.turn(),
+            tt,
         };
 
         td.clear_tables();


### PR DESCRIPTION
```
cosmo@tarski:~/external/EngineTests(master)$ python speedup.py
               master               |              prefetch              |
        mu              sigma       |        mu              sigma       |   Sp(1)/Sp(2)      3*sigma   
------------------------------------+------------------------------------+------------------------------------
       1366948.000             0.000|       1430540.000             0.000|      -4.445 %  +/-  0.000 %
       1355318.500         16446.597|       1429598.500          1331.482|      -5.196 %  +/-  3.186 %
       1344494.667         22061.536|       1435601.000         10439.178|      -6.337 %  +/-  6.341 %
       1345820.000         18207.149|       1437193.250          9099.011|      -6.351 %  +/-  5.178 %
       1334817.200         29222.136|       1425723.000         26831.459|      -6.371 %  +/-  4.486 %
       1330255.333         28425.523|       1422043.500         25635.406|      -6.452 %  +/-  4.056 %
       1315316.429         47281.477|       1411387.857         36639.379|      -6.821 %  +/-  4.723 %
       1304783.750         52949.731|       1396982.125         53017.614|      -6.596 %  +/-  4.771 %
       1292494.889         61744.310|       1395272.111         49858.061|      -7.370 %  +/-  8.275 %
       1287687.500         60165.390|       1395780.700         47034.136|      -7.747 %  +/-  8.581 %
       1288923.545         57224.930|       1397894.182         45167.730|      -7.797 %  +/-  8.156 %
       1287259.917         54865.337|       1396831.250         43222.863|      -7.846 %  +/-  7.793 %
       1287104.615         52532.545|       1398700.385         41927.901|      -7.978 %  +/-  7.596 %
       1288403.286         50705.007|       1400460.786         40817.989|      -8.001 %  +/-  7.303 %
       1289243.800         48968.888|       1401445.067         39517.498|      -8.005 %  +/-  7.037 %
       1288472.125         47409.032|       1401758.312         38198.086|      -8.081 %  +/-  6.859 %
       1288444.471         45903.739|       1401158.176         37067.818|      -8.043 %  +/-  6.657 %
       1288257.278         44540.249|       1396812.222         40412.498|      -7.755 %  +/-  7.425 %
       1286419.474         44020.379|       1396967.579         39279.726|      -7.898 %  +/-  7.452 %
       1285750.700         42950.550|       1396687.900         38252.532|      -7.928 %  +/-  7.265 %
       1286415.095         41973.589|       1398063.619         37813.200|      -7.971 %  +/-  7.106 %
       1287736.727         41428.437|       1397913.409         36908.629|      -7.867 %  +/-  7.087 %
       1286696.739         40782.071|       1397518.522         36109.737|      -7.916 %  +/-  6.960 %
       1287575.583         40117.353|       1398304.417         35525.264|      -7.906 %  +/-  6.809 %
       1288303.640         39441.036|       1399276.400         35115.211|      -7.918 %  +/-  6.668 %
       1288491.923         38656.089|       1398444.885         34666.003|      -7.849 %  +/-  6.618 %
       1286126.704         39848.030|       1398334.444         33997.656|      -8.012 %  +/-  6.967 %
       1286648.857         39200.634|       1397317.179         33793.593|      -7.906 %  +/-  7.041 %
       1286711.862         38495.753|       1396420.207         33534.358|      -7.842 %  +/-  6.992 %
       1285893.100         38091.119|       1395081.467         33757.107|      -7.812 %  +/-  6.888 %
       1285062.323         37735.459|       1392967.613         35214.730|      -7.728 %  +/-  6.915 %
       1282538.969         39771.655|       1392825.312         34651.446|      -7.901 %  +/-  7.408 %
       1283518.848         39547.936|       1392935.970         34111.643|      -7.839 %  +/-  7.370 %
       1282482.353         39410.291|       1393406.324         33702.602|      -7.943 %  +/-  7.485 %
```