### PR TITLE
Reduce quiets more when the TT-move is a capture.

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -779,6 +779,7 @@ impl Board {
         }
 
         let mut tt_move = tt_hit.map_or(Move::NULL, |hit| hit.mov);
+        let tt_capture = !tt_move.is_null() && self.is_capture(tt_move);
 
         if cut_node && depth >= TT_REDUCTION_DEPTH * 2 && tt_move.is_null() {
             depth -= 1;
@@ -1022,6 +1023,8 @@ impl Board {
                         r += i32::from(cut_node);
                         // reduce more if not improving
                         // r += i32::from(!improving);
+                        // reduce more if the move from the transposition table is tactical
+                        r += i32::from(tt_capture);
                     } else if is_winning_capture {
                         // reduce winning captures less
                         r -= 1;


### PR DESCRIPTION
```
Elo   | 2.79 +- 2.65 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 30650 W: 7268 L: 7022 D: 16360
Penta | [125, 3492, 7864, 3700, 144]
https://chess.swehosting.se/test/5777/
```