### PR TITLE
Significantly improve NNUE inference code quality.

### DIFF
--- a/IDEAS.txt
+++ b/IDEAS.txt
@@ -14,13 +14,12 @@ MINOR:
   - locked pawns?
   - bishop pair
   - passed pawns by file?
-- tune nodeTM constants
 - better errors for Fathom.
-- finish the datagen - -> | transition
 - add filtering for counts
 - probcut tinkering (SF in-check trick)
 - futility tinkering
 - use history for more things
 - iir tinkering (ttmove, excluded move, non-PV nodes, other fiddling)
 - iid tinkering (ttmove, excluded move)
-- screlu output is guaranteed to be positive. can we fit bigger quantisation results in our registers?
+- look for bad zero-init of arrays.
+- skip tt entry reload in the store() function.

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,3 @@
-
 use std::env;
 
 fn main() {

--- a/build.rs
+++ b/build.rs
@@ -1,9 +1,23 @@
-#[cfg(any(feature = "bindgen", feature = "syzygy"))]
+
 use std::env;
 
 fn main() {
+    prep_net();
     build_dependencies();
     generate_bindings();
+}
+
+fn prep_net() {
+    let net_path = env::var("EVALFILE").unwrap_or("viridithas.nnue".into());
+    if net_path == "viridithas.nnue" {
+        // check if net exists
+        if let Err(e) = std::fs::metadata(net_path) {
+            eprintln!("Couldn't read default net during build script! {e}");
+            eprintln!("Note: viri looks for a default net in the project root called \"viridithas.nnue\".");
+        }
+        return;
+    }
+    std::fs::copy(net_path, "viridithas.nnue").unwrap();
 }
 
 fn build_dependencies() {

--- a/src/datagen/dataformat.rs
+++ b/src/datagen/dataformat.rs
@@ -94,11 +94,17 @@ impl Game {
             }
             let mv = Move::from_raw(u16::from_le_bytes([buf[0], buf[1]]));
             if !mv.is_valid() || mv.from() == mv.to() {
-                return Err(std::io::Error::new(std::io::ErrorKind::InvalidData, format!("parsed invalid move: {mv:?}")));
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("parsed invalid move: {mv:?}"),
+                ));
             }
             #[cfg(debug_assertions)]
             if !real_board.legal_moves().contains(&mv) {
-                return Err(std::io::Error::new(std::io::ErrorKind::InvalidData, format!("parsed illegal move: {mv:?}")));
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("parsed illegal move: {mv:?}"),
+                ));
             }
             let eval = I16Le::new(i16::from_le_bytes([buf[2], buf[3]]));
             moves.push((mv, eval));

--- a/src/nnue/accumulator.rs
+++ b/src/nnue/accumulator.rs
@@ -2,7 +2,10 @@
 
 use crate::piece::Colour;
 
-use super::{network::{Align64, MovedPiece, PovUpdate, UpdateBuffer, LAYER_1_SIZE}, simd};
+use super::{
+    network::{Align64, MovedPiece, PovUpdate, UpdateBuffer, LAYER_1_SIZE},
+    simd,
+};
 
 /// Activations of the hidden layer.
 #[derive(Debug, Clone)]

--- a/src/nnue/accumulator.rs
+++ b/src/nnue/accumulator.rs
@@ -1,9 +1,9 @@
 // use crate::{board::Board, piece::PieceType};
 
-use super::network::{Align64, MovedPiece, PovUpdate, UpdateBuffer, LAYER_1_SIZE};
+use super::{network::{Align64, MovedPiece, PovUpdate, UpdateBuffer, LAYER_1_SIZE}, simd};
 
 /// Activations of the hidden layer.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct Accumulator {
     pub white: Align64<[i16; LAYER_1_SIZE]>,
     pub black: Align64<[i16; LAYER_1_SIZE]>,
@@ -17,10 +17,10 @@ impl Accumulator {
     /// Initializes the accumulator with the given bias.
     pub fn init(&mut self, bias: &Align64<[i16; LAYER_1_SIZE]>, update: PovUpdate) {
         if update.white {
-            self.white = *bias;
+            simd::copy(bias, &mut self.white);
         }
         if update.black {
-            self.black = *bias;
+            simd::copy(bias, &mut self.black);
         }
     }
 }

--- a/src/nnue/accumulator.rs
+++ b/src/nnue/accumulator.rs
@@ -1,5 +1,7 @@
 // use crate::{board::Board, piece::PieceType};
 
+use crate::piece::Colour;
+
 use super::{network::{Align64, MovedPiece, PovUpdate, UpdateBuffer, LAYER_1_SIZE}, simd};
 
 /// Activations of the hidden layer.
@@ -21,6 +23,14 @@ impl Accumulator {
         }
         if update.black {
             simd::copy(bias, &mut self.black);
+        }
+    }
+
+    /// Select the buffer by colour.
+    pub fn select_mut(&mut self, colour: Colour) -> &mut Align64<[i16; LAYER_1_SIZE]> {
+        match colour {
+            Colour::WHITE => &mut self.white,
+            Colour::BLACK => &mut self.black,
         }
     }
 }

--- a/src/nnue/mod.rs
+++ b/src/nnue/mod.rs
@@ -1,2 +1,3 @@
 mod accumulator;
 pub mod network;
+mod simd;

--- a/src/nnue/network.rs
+++ b/src/nnue/network.rs
@@ -1,5 +1,4 @@
 use std::{
-    env,
     fmt::{Debug, Display},
     mem,
     ops::{Deref, DerefMut},
@@ -50,7 +49,7 @@ const QAB: i32 = QA * QB;
 // read in the binary file containing the network parameters
 // have to do some path manipulation to get relative paths to work
 // SAFETY: alignment to u16 is guaranteed because transmute() is a copy operation.
-pub static NNUE: NNUEParams = unsafe { mem::transmute(*include_bytes!(concat!("../../", "viridithas.nnue",))) };
+pub static NNUE: NNUEParams = unsafe { mem::transmute(*include_bytes!("../../viridithas.nnue")) };
 
 #[repr(C)]
 pub struct NNUEParams {

--- a/src/nnue/network.rs
+++ b/src/nnue/network.rs
@@ -348,10 +348,10 @@ impl BucketAccumulatorCache {
         }
 
         if pov_update.white {
-            acc.white = cache_acc.white;
+            simd::copy(&cache_acc.white, &mut acc.white);
             acc.correct[Colour::WHITE.index()] = true;
         } else {
-            acc.black = cache_acc.black;
+            simd::copy(&cache_acc.black, &mut acc.black);
             acc.correct[Colour::BLACK.index()] = true;
         }
 
@@ -359,7 +359,7 @@ impl BucketAccumulatorCache {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[repr(C, align(64))]
 pub struct Align64<T>(pub T);
 

--- a/src/nnue/network.rs
+++ b/src/nnue/network.rs
@@ -46,6 +46,125 @@ const QA: i32 = 255;
 const QB: i32 = 64;
 const QAB: i32 = QA * QB;
 
+
+
+// read in the binary file containing the network parameters
+// have to do some path manipulation to get relative paths to work
+// SAFETY: alignment to u16 is guaranteed because transmute() is a copy operation.
+pub static NNUE: NNUEParams = unsafe { mem::transmute(*include_bytes!(concat!("../../", "viridithas.nnue",))) };
+
+#[repr(C)]
+pub struct NNUEParams {
+    pub feature_weights: Align64<[i16; INPUT * LAYER_1_SIZE * BUCKETS]>,
+    pub feature_bias: Align64<[i16; LAYER_1_SIZE]>,
+    pub output_weights: Align64<[i16; LAYER_1_SIZE * 2]>,
+    pub output_bias: i16,
+}
+
+impl NNUEParams {
+    pub fn visualise_neuron(&self, neuron: usize, path: &std::path::Path) {
+        #![allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+        // remap pieces to keep opposite colours together
+        static PIECE_REMAPPING: [usize; 12] = [0, 2, 4, 6, 8, 10, 1, 3, 5, 7, 9, 11];
+        assert!(neuron < LAYER_1_SIZE);
+        let starting_idx = neuron;
+        let mut slice = Vec::with_capacity(768);
+        for colour in Colour::all() {
+            for piece_type in PieceType::all() {
+                for square in Square::all() {
+                    let feature_indices = feature_indices(
+                        Square::H1,
+                        Square::H8,
+                        FeatureUpdate { sq: square, piece: Piece::new(colour, piece_type) },
+                    );
+                    let index = feature_indices.0 * LAYER_1_SIZE + starting_idx;
+                    slice.push(self.feature_weights[index]);
+                }
+            }
+        }
+
+        let mut image = Image::zeroed(8 * 6 + 5, 8 * 2 + 1); // + for inter-piece spacing
+
+        for (piece, chunk) in slice.chunks(64).enumerate() {
+            let piece = PIECE_REMAPPING[piece];
+            let piece_colour = piece % 2;
+            let piece_type = piece / 2;
+            let (max, min) = if piece_type == 0 {
+                let chunk = &chunk[8..56]; // first and last rank are always 0 for pawns
+                (*chunk.iter().max().unwrap(), *chunk.iter().min().unwrap())
+            } else {
+                (*chunk.iter().max().unwrap(), *chunk.iter().min().unwrap())
+            };
+            let weight_to_colour = |weight: i16| -> u32 {
+                let intensity = f32::from(weight - min) / f32::from(max - min);
+                let idx = (intensity * 255.0).round() as u8;
+                image::inferno_colour_map(idx)
+            };
+            for (square, &weight) in chunk.iter().enumerate() {
+                let row = square / 8;
+                let col = square % 8;
+                let colour = if (row == 0 || row == 7) && piece_type == 0 {
+                    0 // pawns on first and last rank are always 0
+                } else {
+                    weight_to_colour(weight)
+                };
+                image.set(col + piece_type * 8 + piece_type, row + piece_colour * 9, colour);
+            }
+        }
+
+        let path = path.join(format!("neuron_{neuron}.tga"));
+        image.save_as_tga(path);
+    }
+
+    pub fn min_max_feature_weight(&self) -> (i16, i16) {
+        let mut min = i16::MAX;
+        let mut max = i16::MIN;
+        for &f in &self.feature_weights.0 {
+            if f < min {
+                min = f;
+            }
+            if f > max {
+                max = f;
+            }
+        }
+        (min, max)
+    }
+
+    pub fn min_max_output_weight(&self) -> (i16, i16) {
+        let mut min = i16::MAX;
+        let mut max = i16::MIN;
+        for &f in &self.output_weights.0 {
+            if f < min {
+                min = f;
+            }
+            if f > max {
+                max = f;
+            }
+        }
+        (min, max)
+    }
+
+    pub fn select_feature_weights(&self, bucket: usize) -> &Align64<[i16; INPUT * LAYER_1_SIZE]> {
+        // handle mirroring
+        let bucket = bucket % 9;
+        let start = bucket * INPUT * LAYER_1_SIZE;
+        let end = start + INPUT * LAYER_1_SIZE;
+        let slice = &self.feature_weights[start..end];
+        // SAFETY: The resulting slice is indeed INPUT * LAYER_1_SIZE long,
+        // and we check that the slice is aligned to 64 bytes.
+        // additionally, we're generating the reference from our own data,
+        // so we know that the lifetime is valid.
+        unsafe {
+            // don't immediately cast to Align64, as we want to check the alignment first.
+            let ptr = slice.as_ptr();
+            assert_eq!(ptr.align_offset(64), 0);
+            // alignments are sensible, so we can safely cast.
+            #[allow(clippy::cast_ptr_alignment)]
+            &*ptr.cast()
+        }
+    }
+}
+
 /// The size of the stack used to store the activations of the hidden layer.
 const ACC_STACK_SIZE: usize = MAX_DEPTH.ply_to_horizon() + 1;
 
@@ -255,123 +374,6 @@ impl<T, const SIZE: usize> Deref for Align64<[T; SIZE]> {
 impl<T, const SIZE: usize> DerefMut for Align64<[T; SIZE]> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
-    }
-}
-
-// read in the binary file containing the network parameters
-// have to do some path manipulation to get relative paths to work
-// SAFETY: alignment to u16 is guaranteed because transmute() is a copy operation.
-pub static NNUE: NNUEParams = unsafe { mem::transmute(*include_bytes!(concat!("../../", env!("EVALFILE"),))) };
-
-#[repr(C)]
-pub struct NNUEParams {
-    pub feature_weights: Align64<[i16; INPUT * LAYER_1_SIZE * BUCKETS]>,
-    pub feature_bias: Align64<[i16; LAYER_1_SIZE]>,
-    pub output_weights: Align64<[i16; LAYER_1_SIZE * 2]>,
-    pub output_bias: i16,
-}
-
-impl NNUEParams {
-    pub fn visualise_neuron(&self, neuron: usize, path: &std::path::Path) {
-        #![allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
-        // remap pieces to keep opposite colours together
-        static PIECE_REMAPPING: [usize; 12] = [0, 2, 4, 6, 8, 10, 1, 3, 5, 7, 9, 11];
-        assert!(neuron < LAYER_1_SIZE);
-        let starting_idx = neuron;
-        let mut slice = Vec::with_capacity(768);
-        for colour in Colour::all() {
-            for piece_type in PieceType::all() {
-                for square in Square::all() {
-                    let feature_indices = feature_indices(
-                        Square::H1,
-                        Square::H8,
-                        FeatureUpdate { sq: square, piece: Piece::new(colour, piece_type) },
-                    );
-                    let index = feature_indices.0 * LAYER_1_SIZE + starting_idx;
-                    slice.push(self.feature_weights[index]);
-                }
-            }
-        }
-
-        let mut image = Image::zeroed(8 * 6 + 5, 8 * 2 + 1); // + for inter-piece spacing
-
-        for (piece, chunk) in slice.chunks(64).enumerate() {
-            let piece = PIECE_REMAPPING[piece];
-            let piece_colour = piece % 2;
-            let piece_type = piece / 2;
-            let (max, min) = if piece_type == 0 {
-                let chunk = &chunk[8..56]; // first and last rank are always 0 for pawns
-                (*chunk.iter().max().unwrap(), *chunk.iter().min().unwrap())
-            } else {
-                (*chunk.iter().max().unwrap(), *chunk.iter().min().unwrap())
-            };
-            let weight_to_colour = |weight: i16| -> u32 {
-                let intensity = f32::from(weight - min) / f32::from(max - min);
-                let idx = (intensity * 255.0).round() as u8;
-                image::inferno_colour_map(idx)
-            };
-            for (square, &weight) in chunk.iter().enumerate() {
-                let row = square / 8;
-                let col = square % 8;
-                let colour = if (row == 0 || row == 7) && piece_type == 0 {
-                    0 // pawns on first and last rank are always 0
-                } else {
-                    weight_to_colour(weight)
-                };
-                image.set(col + piece_type * 8 + piece_type, row + piece_colour * 9, colour);
-            }
-        }
-
-        let path = path.join(format!("neuron_{neuron}.tga"));
-        image.save_as_tga(path);
-    }
-
-    pub fn min_max_feature_weight(&self) -> (i16, i16) {
-        let mut min = i16::MAX;
-        let mut max = i16::MIN;
-        for &f in &self.feature_weights.0 {
-            if f < min {
-                min = f;
-            }
-            if f > max {
-                max = f;
-            }
-        }
-        (min, max)
-    }
-
-    pub fn min_max_output_weight(&self) -> (i16, i16) {
-        let mut min = i16::MAX;
-        let mut max = i16::MIN;
-        for &f in &self.output_weights.0 {
-            if f < min {
-                min = f;
-            }
-            if f > max {
-                max = f;
-            }
-        }
-        (min, max)
-    }
-
-    pub fn select_feature_weights(&self, bucket: usize) -> &Align64<[i16; INPUT * LAYER_1_SIZE]> {
-        // handle mirroring
-        let bucket = bucket % 9;
-        let start = bucket * INPUT * LAYER_1_SIZE;
-        let end = start + INPUT * LAYER_1_SIZE;
-        let slice = &self.feature_weights[start..end];
-        // SAFETY: The resulting slice is indeed INPUT * LAYER_1_SIZE long,
-        // and we check that the slice is aligned to 64 bytes.
-        // additionally, we're generating the reference from our own data,
-        // so we know that the lifetime is valid.
-        unsafe {
-            // don't immediately cast to Align64, as we want to check the alignment first.
-            let ptr = slice.as_ptr();
-            assert_eq!(ptr.align_offset(64), 0);
-            // alignments are sensible, so we can safely cast.
-            #[allow(clippy::cast_ptr_alignment)]
-            &*ptr.cast()
-        }
     }
 }
 
@@ -814,18 +816,24 @@ fn flatten(
     them: &Align64<[i16; LAYER_1_SIZE]>,
     weights: &Align64<[i16; LAYER_1_SIZE * 2]>,
 ) -> i32 {
-    #[cfg(target_feature = "avx2")]
+    #[cfg(target_feature = "avx512")]
+    unsafe {
+        avx512::flatten(us, them, weights)
+    }
+    #[cfg(all(target_feature = "avx2", not(target_feature = "avx512")))]
     unsafe {
         avx2::flatten(us, them, weights)
     }
-    #[cfg(not(target_feature = "avx2"))]
-    {
-        generic::flatten(us, them, weights)
+    #[cfg(target_feature = "neon")]
+    unsafe {
+        neon::flatten(us, them, weights)
     }
+    #[cfg(not(any(target_feature = "avx512", target_feature = "avx2", target_feature = "neon")))]
+    generic::flatten(us, them, weights)
 }
 
 /// Non-SIMD implementation of the forward pass.
-#[cfg(not(target_feature = "avx2"))]
+#[cfg(not(any(target_feature = "avx512", target_feature = "avx2", target_feature = "neon")))]
 mod generic {
     use super::{Align64, LAYER_1_SIZE, QA};
 
@@ -928,6 +936,171 @@ mod avx2 {
             let w = load_i16s(weights, LAYER_1_SIZE + i * CHUNK);
             let product = _mm256_madd_epi16(v, _mm256_mullo_epi16(v, w));
             sum = _mm256_add_epi32(sum, product);
+        }
+
+        horizontal_sum_i32(sum) / QA
+    }
+}
+
+#[cfg(target_feature = "avx512")]
+mod avx512 {
+    use super::{Align64, LAYER_1_SIZE, QA};
+    // use std::arch::x86_64::{
+    //     __m256i, _mm256_add_epi32, _mm256_castsi256_si128, _mm256_extracti128_si256, _mm256_load_si256,
+    //     _mm256_madd_epi16, _mm256_max_epi16, _mm256_min_epi16, _mm256_mullo_epi16, _mm256_set1_epi16,
+    //     _mm256_setzero_si256, _mm_add_epi32, _mm_cvtsi128_si32, _mm_shuffle_epi32, _mm_unpackhi_epi64,
+    // };
+    use std::arch::x86_64::*;
+
+    type Vec512 = __m512i;
+
+    #[inline]
+    unsafe fn load_i16s<const VEC_SIZE: usize>(acc: &Align64<[i16; VEC_SIZE]>, start_idx: usize) -> Vec512 {
+        _mm512_load_si512(acc.0.as_ptr().add(start_idx).cast())
+    }
+
+    #[inline]
+    unsafe fn horizontal_sum_i32(sum: Vec512) -> i32 {
+        let high_256 = _mm512_extracti64x4_epi64(sum);
+        let low_256 = _mm512_castsi512_si256(sum);
+        let sum_256 = _mm256_add_epi32(low_256, high_256);
+        let upper_128 = _mm256_extracti128_si256::<1>(sum_256);
+        let lower_128 = _mm256_castsi256_si128(sum_256);
+        let sum_128 = _mm_add_epi32(upper_128, lower_128);
+        let upper_64 = _mm_unpackhi_epi64(sum_128, sum_128);
+        let sum_64 = _mm_add_epi32(upper_64, sum_128);
+        let upper_32 = _mm_shuffle_epi32::<0b00_00_00_01>(sum_64);
+        let sum_32 = _mm_add_epi32(upper_32, sum_64);
+
+        _mm_cvtsi128_si32(sum_32)
+    }
+
+    /// Execute an activation on the partial activations,
+    /// and accumulate the result into a sum.
+    pub unsafe fn flatten(
+        us: &Align64<[i16; LAYER_1_SIZE]>,
+        them: &Align64<[i16; LAYER_1_SIZE]>,
+        weights: &Align64<[i16; LAYER_1_SIZE * 2]>,
+    ) -> i32 {
+        const CHUNK: usize = 32;
+
+        let mut sum = _mm512_setzero_si512();
+        let min = _mm512_setzero_si512();
+        let max = _mm512_set1_epi16(QA as i16);
+
+        // the following code uses a trick devised by the author of the Lizard chess engine.
+        // we're implementing the function f(x) = clamp(x, 0, QA)^2 * w,
+        // and we do this in the following manner:
+        // 1. load the input, x
+        // 2. compute v := clamp(x, 0, QA)
+        // 3. load the weight, w
+        // 4. compute t := v * w via truncating 16-bit multiply.
+        //    this step relies on our invariant that v * w fits in i16.
+        // 5. compute product := v * t via horizontally accumulating
+        //    expand-to-i32 multiply.
+        // 6. add product to the running sum.
+        // at this point we've computed clamp(x, 0, QA)^2 * w
+        // by doing (clamp(x, 0, QA) * w) * clamp(x, 0, QA).
+        // the clever part is step #4, which the compiler cannot know to do.
+
+        // accumulate the first half of the weights
+        for i in 0..LAYER_1_SIZE / CHUNK {
+            let x = load_i16s(us, i * CHUNK);
+            let v = _mm512_min_epi16(_mm512_max_epi16(x, min), max);
+            let w = load_i16s(weights, i * CHUNK);
+            let product = _mm512_madd_epi16(v, _mm512_mullo_epi16(v, w));
+            sum = _mm512_add_epi32(sum, product);
+        }
+
+        // accumulate the second half of the weights
+        for i in 0..LAYER_1_SIZE / CHUNK {
+            let x = load_i16s(them, i * CHUNK);
+            let v = _mm512_min_epi16(_mm512_max_epi16(x, min), max);
+            let w = load_i16s(weights, LAYER_1_SIZE + i * CHUNK);
+            let product = _mm512_madd_epi16(v, _mm512_mullo_epi16(v, w));
+            sum = _mm512_add_epi32(sum, product);
+        }
+
+        horizontal_sum_i32(sum) / QA
+    }
+}
+
+#[cfg(target_feature = "neon")]
+mod neon {
+    use super::{Align64, LAYER_1_SIZE, QA};
+    use std::arch::aarch64::*;
+
+    #[inline]
+    unsafe fn load_i16s<const VEC_SIZE: usize>(
+        acc: &Align64<[i16; VEC_SIZE]>,
+        start_idx: usize,
+    ) -> int16x8_t {
+        vld1q_s16(acc.0.as_ptr().add(start_idx).cast())
+    }
+
+    #[inline]
+    unsafe fn horizontal_sum_i32(sum: int32x4_t) -> i32 {
+        vaddlvq_s32(sum) as i32
+    }
+
+    #[inline]
+    unsafe fn madd(a: int16x8_t, b: int16x8_t) -> int32x4_t {
+        let a_lo = vget_low_s16(a);
+        let b_lo = vget_low_s16(b);
+        let a_hi = vget_high_s16(a);
+        let b_hi = vget_high_s16(b);
+        let product_lo = vmull_s16(a_lo, b_lo);
+        let product_hi = vmull_s16(a_hi, b_hi);
+        vaddq_s32(product_lo, product_hi)
+    }
+
+    /// Execute an activation on the partial activations,
+    /// and accumulate the result into a sum.
+    pub unsafe fn flatten(
+        us: &Align64<[i16; LAYER_1_SIZE]>,
+        them: &Align64<[i16; LAYER_1_SIZE]>,
+        weights: &Align64<[i16; LAYER_1_SIZE * 2]>,
+    ) -> i32 {
+        const CHUNK: usize = 8;
+        const QA_I16: i16 = QA as i16;
+
+        let mut sum = vld1q_dup_s32(&0);
+        let min = vld1q_dup_s16(&0);
+        let max = vld1q_dup_s16(&QA_I16);
+
+        // the following code uses a trick devised by the author of the Lizard chess engine.
+        // we're implementing the function f(x) = clamp(x, 0, MAX)^2 * w,
+        // and we do this in the following manner:
+        // 1. load the input, x
+        // 2. compute v := clamp(x, 0, MAX)
+        // 3. load the weight, w
+        // 4. compute t := v * w via truncating 16-bit multiply.
+        //    this step relies on our invariant that v * w fits in i16.
+        // 5. compute product := v * t via horizontally accumulating
+        //    expand-to-i32 multiply.
+        // 6. add product to the running sum.
+        // at this point we've computed clamp(x, 0, MAX)^2 * w
+        // by doing (clamp(x, 0, MAX) * w) * clamp(x, 0, MAX).
+        // the clever part is step #4, which the compiler cannot know to do.
+
+        // accumulate the first half of the weights
+        for i in 0..LAYER_1_SIZE / CHUNK {
+            let x = load_i16s(us, i * CHUNK);
+            let v = vminq_s16(vmaxq_s16(x, min), max);
+            let w = load_i16s(weights, i * CHUNK);
+            let t = vmulq_s16(v, w);
+            let product = madd(v, t);
+            sum = vaddq_s32(sum, product);
+        }
+
+        // accumulate the second half of the weights
+        for i in 0..LAYER_1_SIZE / CHUNK {
+            let x = load_i16s(them, i * CHUNK);
+            let v = vminq_s16(vmaxq_s16(x, min), max);
+            let w = load_i16s(weights, LAYER_1_SIZE + i * CHUNK);
+            let t = vmulq_s16(v, w);
+            let product = madd(v, t);
+            sum = vaddq_s32(sum, product);
         }
 
         horizontal_sum_i32(sum) / QA

--- a/src/nnue/network/feature.rs
+++ b/src/nnue/network/feature.rs
@@ -1,0 +1,36 @@
+use crate::util::File;
+
+use super::FeatureUpdate;
+
+use crate::util::Square;
+
+use super::INPUT;
+
+/// wrapper to enforce bounds.
+#[allow(clippy::module_name_repetitions)]
+#[derive(Clone, Copy)]
+pub struct FeatureIndex(usize);
+
+impl FeatureIndex {
+    pub const fn index(self) -> usize {
+        self.0
+    }
+}
+
+pub const fn indices(white_king: Square, black_king: Square, f: FeatureUpdate) -> (FeatureIndex, FeatureIndex) {
+    const COLOUR_STRIDE: usize = 64 * 6;
+    const PIECE_STRIDE: usize = 64;
+
+    let white_sq = if white_king.file() >= File::FILE_E { f.sq.flip_file() } else { f.sq };
+    let black_sq = if black_king.file() >= File::FILE_E { f.sq.flip_file() } else { f.sq };
+
+    let piece_type = f.piece.piece_type().index();
+    let colour = f.piece.colour().index();
+
+    let white_idx = colour * COLOUR_STRIDE + piece_type * PIECE_STRIDE + white_sq.index();
+    let black_idx = (1 ^ colour) * COLOUR_STRIDE + piece_type * PIECE_STRIDE + black_sq.flip_rank().index();
+
+    // SAFETY: important invariant being upheld here!!
+    assert!(white_idx < INPUT && black_idx < INPUT, "attempt to construct illegal FeatureIndex.");
+    (FeatureIndex(white_idx), FeatureIndex(black_idx))
+}

--- a/src/nnue/simd.rs
+++ b/src/nnue/simd.rs
@@ -1,0 +1,201 @@
+#![allow(clippy::all, clippy::nursery, clippy::pedantic, dead_code)]
+
+use super::network::Align64;
+
+#[derive(Clone, Copy)]
+pub struct Vector16 {
+    #[cfg(target_feature = "avx512")]
+    data: std::arch::x86_64::__m512i,
+    #[cfg(all(target_feature = "avx2", not(target_feature = "avx512")))]
+    data: std::arch::x86_64::__m256i,
+    #[cfg(target_feature = "neon")]
+    data: std::arch::aarch64::int16x8_t,
+    #[cfg(not(any(target_feature = "avx512", target_feature = "avx2", target_feature = "neon")))]
+    data: i16,
+}
+
+#[derive(Clone, Copy)]
+pub struct Vector32 {
+    #[cfg(target_feature = "avx512")]
+    data: std::arch::x86_64::__m512i,
+    #[cfg(all(target_feature = "avx2", not(target_feature = "avx512")))]
+    data: std::arch::x86_64::__m256i,
+    #[cfg(target_feature = "neon")]
+    data: std::arch::aarch64::int32x4_t,
+    #[cfg(not(any(target_feature = "avx512", target_feature = "avx2", target_feature = "neon")))]
+    data: i32,
+}
+
+impl Vector16 {
+    pub const SIZE: usize = std::mem::size_of::<Self>();
+    pub const COUNT: usize = Self::SIZE / std::mem::size_of::<i16>();
+
+    pub fn new(
+        #[cfg(target_feature = "avx512")]
+        data: std::arch::x86_64::__m512i,
+        #[cfg(all(target_feature = "avx2", not(target_feature = "avx512")))]
+        data: std::arch::x86_64::__m256i,
+        #[cfg(target_feature = "neon")]
+        data: std::arch::aarch64::int16x8_t,
+        #[cfg(not(any(target_feature = "avx512", target_feature = "avx2", target_feature = "neon")))]
+        data: i16,
+    ) -> Self {
+        Self { data }
+    }
+
+    #[inline]
+    pub unsafe fn load_at<const VEC_SIZE: usize>(memory: &Align64<[i16; VEC_SIZE]>, start_idx: usize) -> Self {
+        #[cfg(target_feature = "avx512")]
+        { Self { data: std::arch::x86_64::_mm512_load_si512(memory.0.as_ptr().add(start_idx).cast()) } }
+        #[cfg(all(target_feature = "avx2", not(target_feature = "avx512")))]
+        { Self { data: std::arch::x86_64::_mm256_load_si256(memory.0.as_ptr().add(start_idx).cast()) } }
+        #[cfg(target_feature = "neon")]
+        { Self { data: std::arch::aarch64::vld1q_s16(memory.0.as_ptr().add(start_idx).cast()) } }
+        #[cfg(not(any(target_feature = "avx512", target_feature = "avx2", target_feature = "neon")))]
+        { Self { data: *memory.get_unchecked(start_idx) } }
+    }
+
+    #[inline]
+    pub unsafe fn min(a: Self, b: Self) -> Self {
+        #[cfg(target_feature = "avx512")]
+        { Self { data: std::arch::x86_64::_mm512_min_epi16(a.data, b.data) } }
+        #[cfg(all(target_feature = "avx2", not(target_feature = "avx512")))]
+        { Self { data: std::arch::x86_64::_mm256_min_epi16(a.data, b.data) } }
+        #[cfg(target_feature = "neon")]
+        { Self { data: std::arch::aarch64::vminq_s16(a.data, b.data) } }
+        #[cfg(not(any(target_feature = "avx512", target_feature = "avx2", target_feature = "neon")))]
+        { Self { data: std::cmp::min(a.data, b.data) } }
+    }
+
+    #[inline]
+    pub unsafe fn max(a: Self, b: Self) -> Self {
+        #[cfg(target_feature = "avx512")]
+        { Self { data: std::arch::x86_64::_mm512_max_epi16(a.data, b.data) } }
+        #[cfg(all(target_feature = "avx2", not(target_feature = "avx512")))]
+        { Self { data: std::arch::x86_64::_mm256_max_epi16(a.data, b.data) } }
+        #[cfg(target_feature = "neon")]
+        { Self { data: std::arch::aarch64::vmaxq_s16(a.data, b.data) } }
+        #[cfg(not(any(target_feature = "avx512", target_feature = "avx2", target_feature = "neon")))]
+        { Self { data: std::cmp::max(a.data, b.data) } }
+    }
+
+    #[inline]
+    pub unsafe fn mul_truncating(a: Self, b: Self) -> Self {
+        #[cfg(target_feature = "avx512")]
+        { Self { data: std::arch::x86_64::_mm512_mullo_epi16(a.data, b.data) } }
+        #[cfg(all(target_feature = "avx2", not(target_feature = "avx512")))]
+        { Self { data: std::arch::x86_64::_mm256_mullo_epi16(a.data, b.data) } }
+        #[cfg(target_feature = "neon")]
+        { Self { data: std::arch::aarch64::vmulq_s16(a.data, b.data) } }
+        #[cfg(not(any(target_feature = "avx512", target_feature = "avx2", target_feature = "neon")))]
+        { Self { data: a.data * b.data } }
+    }
+
+    #[inline]
+    pub unsafe fn mul_widening(a: Self, b: Self) -> Vector32 {
+        #[cfg(target_feature = "avx512")]
+        { Vector32 { data: std::arch::x86_64::_mm512_madd_epi16(a.data, b.data) } }
+        #[cfg(all(target_feature = "avx2", not(target_feature = "avx512")))]
+        { Vector32 { data: std::arch::x86_64::_mm256_madd_epi16(a.data, b.data) } }
+        #[cfg(target_feature = "neon")]
+        {
+            let a_lo = std::arch::aarch64::vget_low_s16(a.data);
+            let b_lo = std::arch::aarch64::vget_low_s16(b.data);
+            let a_hi = std::arch::aarch64::vget_high_s16(a.data);
+            let b_hi = std::arch::aarch64::vget_high_s16(b.data);
+            let product_lo = std::arch::aarch64::vmull_s16(a_lo, b_lo);
+            let product_hi = std::arch::aarch64::vmull_s16(a_hi, b_hi);
+            Vector32 { data: std::arch::aarch64::vaddq_s32(product_lo, product_hi) }
+        }
+        #[cfg(not(any(target_feature = "avx512", target_feature = "avx2", target_feature = "neon")))]
+        { Vector32 { data: i32::from(a.data) * i32::from(b.data) } }
+    }
+
+    #[inline]
+    pub unsafe fn splat(value: i16) -> Self {
+        #[cfg(target_feature = "avx512")]
+        { Self { data: std::arch::x86_64::_mm512_set1_epi16(value) } }
+        #[cfg(all(target_feature = "avx2", not(target_feature = "avx512")))]
+        { Self { data: std::arch::x86_64::_mm256_set1_epi16(value) } }
+        #[cfg(target_feature = "neon")]
+        { Self { data: std::arch::aarch64::vld1q_dup_s16(&value) } }
+        #[cfg(not(any(target_feature = "avx512", target_feature = "avx2", target_feature = "neon")))]
+        { Self { data: value } }
+    }
+
+    #[inline]
+    pub unsafe fn zero() -> Self {
+        #[cfg(target_feature = "avx512")]
+        { Self { data: std::arch::x86_64::_mm512_setzero_si512() } }
+        #[cfg(all(target_feature = "avx2", not(target_feature = "avx512")))]
+        { Self { data: std::arch::x86_64::_mm256_setzero_si256() } }
+        #[cfg(target_feature = "neon")]
+        { Self { data: std::arch::aarch64::vld1q_dup_s16(&0) } }
+        #[cfg(not(any(target_feature = "avx512", target_feature = "avx2", target_feature = "neon")))]
+        { Self { data: 0 } }
+    }
+}
+
+impl Vector32 {
+    pub const SIZE: usize = std::mem::size_of::<Self>();
+    pub const COUNT: usize = Self::SIZE / std::mem::size_of::<i32>();
+
+    #[inline]
+    pub unsafe fn add(a: Self, b: Self) -> Self {
+        #[cfg(target_feature = "avx512")]
+        { Self { data: std::arch::x86_64::_mm512_add_epi32(a.data, b.data) } }
+        #[cfg(all(target_feature = "avx2", not(target_feature = "avx512")))]
+        { Self { data: std::arch::x86_64::_mm256_add_epi32(a.data, b.data) } }
+        #[cfg(target_feature = "neon")]
+        { Self { data: std::arch::aarch64::vaddq_s32(a.data, b.data) } }
+        #[cfg(not(any(target_feature = "avx512", target_feature = "avx2", target_feature = "neon")))]
+        { Self { data: a.data + b.data } }
+    }
+
+    #[inline]
+    pub unsafe fn sum(a: Self) -> i32 {
+        #[cfg(target_feature = "avx512")]
+        {
+            let high_256 = std::arch::x86_64::_mm512_extracti64x4_epi64(a.data);
+            let low_256 = std::arch::x86_64::_mm512_castsi512_si256(a.data);
+            let sum_256 = std::arch::x86_64::_mm256_add_epi32(low_256, high_256);
+            let upper_128 = std::arch::x86_64::_mm256_extracti128_si256::<1>(sum_256);
+            let lower_128 = std::arch::x86_64::_mm256_castsi256_si128(sum_256);
+            let sum_128 = std::arch::x86_64::_mm_add_epi32(upper_128, lower_128);
+            let upper_64 = std::arch::x86_64::_mm_unpackhi_epi64(sum_128, sum_128);
+            let sum_64 = std::arch::x86_64::_mm_add_epi32(upper_64, sum_128);
+            let upper_32 = std::arch::x86_64::_mm_shuffle_epi32::<0b00_00_00_01>(sum_64);
+            let sum_32 = std::arch::x86_64::_mm_add_epi32(upper_32, sum_64);
+
+            std::arch::x86_64::_mm_cvtsi128_si32(sum_32)
+        }
+        #[cfg(all(target_feature = "avx2", not(target_feature = "avx512")))]
+        {
+            let upper_128 = std::arch::x86_64::_mm256_extracti128_si256::<1>(a.data);
+            let lower_128 = std::arch::x86_64::_mm256_castsi256_si128(a.data);
+            let sum_128 = std::arch::x86_64::_mm_add_epi32(upper_128, lower_128);
+            let upper_64 = std::arch::x86_64::_mm_unpackhi_epi64(sum_128, sum_128);
+            let sum_64 = std::arch::x86_64::_mm_add_epi32(upper_64, sum_128);
+            let upper_32 = std::arch::x86_64::_mm_shuffle_epi32::<0b00_00_00_01>(sum_64);
+            let sum_32 = std::arch::x86_64::_mm_add_epi32(upper_32, sum_64);
+
+            std::arch::x86_64::_mm_cvtsi128_si32(sum_32)
+        }
+        #[cfg(target_feature = "neon")]
+        { std::arch::aarch64::vaddlvq_s32(a.data) as i32 }
+        #[cfg(not(any(target_feature = "avx512", target_feature = "avx2", target_feature = "neon")))]
+        { a.data }
+    }
+
+    #[inline]
+    pub unsafe fn zero() -> Self {
+        #[cfg(target_feature = "avx512")]
+        { Self { data: std::arch::x86_64::_mm512_setzero_si512() } }
+        #[cfg(all(target_feature = "avx2", not(target_feature = "avx512")))]
+        { Self { data: std::arch::x86_64::_mm256_setzero_si256() } }
+        #[cfg(target_feature = "neon")]
+        { Self { data: std::arch::aarch64::vld1q_dup_s32(&0) } }
+        #[cfg(not(any(target_feature = "avx512", target_feature = "avx2", target_feature = "neon")))]
+        { Self { data: 0 } }
+    }
+}

--- a/src/nnue/simd.rs
+++ b/src/nnue/simd.rs
@@ -220,13 +220,31 @@ impl Vector16 {
         }
         #[cfg(target_feature = "neon")]
         {
-            let a_lo = std::arch::aarch64::vget_low_s16(a.data);
-            let b_lo = std::arch::aarch64::vget_low_s16(b.data);
-            let a_hi = std::arch::aarch64::vget_high_s16(a.data);
-            let b_hi = std::arch::aarch64::vget_high_s16(b.data);
-            let product_lo = std::arch::aarch64::vmull_s16(a_lo, b_lo);
-            let product_hi = std::arch::aarch64::vmull_s16(a_hi, b_hi);
-            Vector32 { data: std::arch::aarch64::vaddq_s32(product_lo, product_hi) }
+            // an attempt to interpret the following GCC-emitted SIMD:
+            // ldp     d0, d1, [x0]        // load a.data into d0 and d1
+            // ldp     d2, d3, [x1]        // load b.data into d2 and d3
+            // uzp2    v4.4h, v0.4h, v1.4h // run vuzp2_s16 against d0 and d1, into d4
+            // uzp1    v1.4h, v0.4h, v1.4h // run vuzp1_s16 against d0 and d1, into d1
+            // uzp2    v0.4h, v2.4h, v3.4h // run vuzp2_s16 against d2 and d3, into d0
+            // uzp1    v2.4h, v2.4h, v3.4h // run vuzp1_s16 against d2 and d3, into d2
+            // smull   v0.4s, v0.4h, v4.4h // multiply d0 and d4 into d0
+            // smlal   v0.4s, v2.4h, v1.4h // multiply-accumulate d2 and d1 into d0
+            // str     q0, [x8]            // store.
+
+            // load bits
+            let d0 = std::arch::aarch64::vget_low_s16(a.data);
+            let d1 = std::arch::aarch64::vget_high_s16(a.data);
+            let d2 = std::arch::aarch64::vget_low_s16(b.data);
+            let d3 = std::arch::aarch64::vget_high_s16(b.data);
+            // unzipping
+            let d4 = std::arch::aarch64::vuzp2_s16(d0, d1);
+            let d1 = std::arch::aarch64::vuzp1_s16(d0, d1);
+            let d0 = std::arch::aarch64::vuzp2_s16(d2, d3);
+            let d2 = std::arch::aarch64::vuzp1_s16(d2, d3);
+            // multiplication
+            let d0 = std::arch::aarch64::vmull_s16(d0, d4);
+            let d0 = std::arch::aarch64::vmlal_s16(d0, d2, d1);
+            Vector32 { data: d0 }
         }
         #[cfg(not(any(target_feature = "avx512", target_feature = "avx2", target_feature = "neon")))]
         {

--- a/src/nnue/simd.rs
+++ b/src/nnue/simd.rs
@@ -218,21 +218,16 @@ impl Vector16 {
         {
             Vector32 { data: std::arch::x86_64::_mm256_madd_epi16(a.data, b.data) }
         }
-        // #[cfg(target_feature = "neon")]
+        #[cfg(target_feature = "neon")]
         {
             // load bits
             let a_lo = std::arch::aarch64::vget_low_s16(a.data);
             let a_hi = std::arch::aarch64::vget_high_s16(a.data);
             let b_lo = std::arch::aarch64::vget_low_s16(b.data);
             let b_hi = std::arch::aarch64::vget_high_s16(b.data);
-            // unzipping
-            let a_z2 = std::arch::aarch64::vuzp2_s16(a_lo, a_hi);
-            let a_z1 = std::arch::aarch64::vuzp1_s16(a_lo, a_hi);
-            let b_z2 = std::arch::aarch64::vuzp2_s16(b_lo, b_hi);
-            let b_z1 = std::arch::aarch64::vuzp1_s16(b_lo, b_hi);
             // multiplication
-            let acc = std::arch::aarch64::vmull_s16(b_z2, a_z2);
-            let acc = std::arch::aarch64::vmlal_s16(acc, b_z1, a_z1);
+            let acc = std::arch::aarch64::vmull_s16(b_lo, a_lo);
+            let acc = std::arch::aarch64::vmlal_s16(acc, b_hi, a_hi);
             Vector32 { data: acc }
         }
         #[cfg(not(any(target_feature = "avx512", target_feature = "avx2", target_feature = "neon")))]

--- a/src/nnue/simd.rs
+++ b/src/nnue/simd.rs
@@ -273,6 +273,15 @@ unsafe fn slice_to_aligned(slice: &[i16]) -> &Align64<[i16; LAYER_1_SIZE]> {
     }
 }
 
+/// Vector-accelerated memcopy.
+pub fn copy(src: &Align64<[i16; LAYER_1_SIZE]>, tgt: &mut Align64<[i16; LAYER_1_SIZE]>) {
+    for i in 0..LAYER_1_SIZE / Vector16::COUNT {
+        unsafe {
+            Vector16::store_at(tgt, Vector16::load_at(src, i * Vector16::COUNT), i * Vector16::COUNT);
+        }
+    }
+}
+
 /// Add a feature to a square.
 pub fn vector_add_inplace(
     input: &mut Align64<[i16; LAYER_1_SIZE]>,


### PR DESCRIPTION
This PR adds a generic SIMD abstraction for writing NNUE inference code, and uses it to improve the code quality and performance for viri's NNUE.

AVX2 performance is ~equal and passes nonregression:
```
Elo   | -0.16 +- 2.52 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.06 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 34012 W: 7967 L: 7983 D: 18062
Penta | [130, 3648, 9490, 3584, 154]
https://chess.swehosting.se/test/6428/
```

AVX512 performance is a ~28.9% speedup over master.
ARM NEON performance, however, has /cratered/, at about 30% slower than before. 
I am working on fixing this, and will immediately create a development branch for that after merging this one.