### PR TITLE
Optimise loop unrolling of accumulator refreshes.

### DIFF
--- a/src/nnue/network/feature.rs
+++ b/src/nnue/network/feature.rs
@@ -12,6 +12,8 @@ use super::INPUT;
 pub struct FeatureIndex(usize);
 
 impl FeatureIndex {
+    /// Invariant: the result of this function is less than the number of NNUE input features (768),
+    /// so it can be used to index a row of the feature-transformer matrix without bounds checking.
     pub const fn index(self) -> usize {
         self.0
     }

--- a/src/nnue/simd.rs
+++ b/src/nnue/simd.rs
@@ -386,33 +386,33 @@ pub fn vector_update_inplace(
     adds: &[FeatureIndex],
     subs: &[FeatureIndex],
 ) {
-    const REGISTERS: usize = 8;
+    const REGISTERS: usize = 16;
     const UNROLL: usize = Vector16::COUNT * REGISTERS;
     let mut registers = [unsafe { Vector16::zero() }; 16];
     for i in 0..LAYER_1_SIZE / UNROLL {
         let unroll_offset = i * UNROLL;
         unsafe {
-            for r in 0..REGISTERS {
-                registers[r] = Vector16::load_at(input, unroll_offset + r * Vector16::COUNT);
+            for (r_idx, reg) in registers.iter_mut().enumerate() {
+                *reg = Vector16::load_at(input, unroll_offset + r_idx * Vector16::COUNT);
             }
-            for r in 0..REGISTERS {
-                for &sub_index in subs {
-                    let sub_index = sub_index.index() * LAYER_1_SIZE;
-                    let sub_block = slice_to_aligned(&bucket[sub_index..sub_index + LAYER_1_SIZE]);
-                    let sub = Vector16::load_at(sub_block, unroll_offset + r * Vector16::COUNT);
-                    registers[r] = Vector16::sub(registers[r], sub);
+            for &sub_index in subs {
+                let sub_index = sub_index.index() * LAYER_1_SIZE;
+                let sub_block = slice_to_aligned(bucket.get_unchecked(sub_index..sub_index + LAYER_1_SIZE));
+                for (r_idx, reg) in registers.iter_mut().enumerate() {
+                    let sub = Vector16::load_at(sub_block, unroll_offset + r_idx * Vector16::COUNT);
+                    *reg = Vector16::sub(*reg, sub);
                 }
             }
-            for r in 0..REGISTERS {
-                for &add_index in adds {
-                    let add_index = add_index.index() * LAYER_1_SIZE;
-                    let add_block = slice_to_aligned(&bucket[add_index..add_index + LAYER_1_SIZE]);
-                    let add = Vector16::load_at(add_block, unroll_offset + r * Vector16::COUNT);
-                    registers[r] = Vector16::add(registers[r], add);
+            for &add_index in adds {
+                let add_index = add_index.index() * LAYER_1_SIZE;
+                let add_block = slice_to_aligned(bucket.get_unchecked(add_index..add_index + LAYER_1_SIZE));
+                for (r_idx, reg) in registers.iter_mut().enumerate() {
+                    let add = Vector16::load_at(add_block, unroll_offset + r_idx * Vector16::COUNT);
+                    *reg = Vector16::add(*reg, add);
                 }
             }
-            for r in 0..REGISTERS {
-                Vector16::store_at(input, registers[r], unroll_offset + r * Vector16::COUNT);
+            for (r_idx, reg) in registers.iter().enumerate() {
+                Vector16::store_at(input, *reg, unroll_offset + r_idx * Vector16::COUNT);
             }
         }
     }

--- a/src/nnue/simd.rs
+++ b/src/nnue/simd.rs
@@ -379,9 +379,6 @@ pub fn copy(src: &Align64<[i16; LAYER_1_SIZE]>, dst: &mut Align64<[i16; LAYER_1_
     unsafe { std::ptr::copy_nonoverlapping(src, dst, 1) };
 }
 
-const REGISTERS: usize = 16;
-const UNROLL: usize = Vector16::COUNT * REGISTERS;
-
 /// Apply add/subtract updates in place.
 pub fn vector_update_inplace(
     input: &mut Align64<[i16; LAYER_1_SIZE]>,
@@ -389,6 +386,8 @@ pub fn vector_update_inplace(
     adds: &[FeatureIndex],
     subs: &[FeatureIndex],
 ) {
+    const REGISTERS: usize = 16;
+    const UNROLL: usize = Vector16::COUNT * REGISTERS;
     let mut registers = [unsafe { Vector16::zero() }; 16];
     for i in 0..LAYER_1_SIZE / UNROLL {
         let unroll_offset = i * UNROLL;
@@ -429,31 +428,16 @@ pub fn vector_add_sub(
 ) {
     let offset_add = feature_idx_add.index() * LAYER_1_SIZE;
     let offset_sub = feature_idx_sub.index() * LAYER_1_SIZE;
-    unsafe {
-        let s_block = slice_to_aligned(bucket.get_unchecked(offset_sub..offset_sub + LAYER_1_SIZE));
-        let a_block = slice_to_aligned(bucket.get_unchecked(offset_add..offset_add + LAYER_1_SIZE));
-
-        let mut registers: [Vector16; 16] = [Vector16::zero(); 16];
-        for i in 0..LAYER_1_SIZE / UNROLL {
-            let unroll_offset = i * UNROLL;
-
-            for (r_idx, reg) in registers.iter_mut().enumerate() {
-                *reg = Vector16::load_at(input, unroll_offset + r_idx * Vector16::COUNT);
-            }
-
-            for (r_idx, reg) in registers.iter_mut().enumerate() {
-                let w_sub = Vector16::load_at(s_block, unroll_offset + r_idx * Vector16::COUNT);
-                *reg = Vector16::sub(*reg, w_sub);
-            }
-
-            for (r_idx, reg) in registers.iter_mut().enumerate() {
-                let w_add = Vector16::load_at(a_block, unroll_offset + r_idx * Vector16::COUNT);
-                *reg = Vector16::add(*reg, w_add);
-            }
-
-            for (r_idx, reg) in registers.iter().enumerate() {
-                Vector16::store_at(output, *reg, unroll_offset + r_idx * Vector16::COUNT);
-            }
+    let s_block = unsafe { slice_to_aligned(bucket.get_unchecked(offset_sub..offset_sub + LAYER_1_SIZE)) };
+    let a_block = unsafe { slice_to_aligned(bucket.get_unchecked(offset_add..offset_add + LAYER_1_SIZE)) };
+    for i in 0..LAYER_1_SIZE / Vector16::COUNT {
+        unsafe {
+            let x = Vector16::load_at(input, i * Vector16::COUNT);
+            let w_sub = Vector16::load_at(s_block, i * Vector16::COUNT);
+            let w_add = Vector16::load_at(a_block, i * Vector16::COUNT);
+            let t = Vector16::sub(x, w_sub);
+            let t = Vector16::add(t, w_add);
+            Vector16::store_at(output, t, i * Vector16::COUNT);
         }
     }
 }
@@ -470,37 +454,19 @@ pub fn vector_add_sub2(
     let offset_add = feature_idx_add.index() * LAYER_1_SIZE;
     let offset_sub1 = feature_idx_sub1.index() * LAYER_1_SIZE;
     let offset_sub2 = feature_idx_sub2.index() * LAYER_1_SIZE;
-    unsafe {
-        let a_block = slice_to_aligned(bucket.get_unchecked(offset_add..offset_add + LAYER_1_SIZE));
-        let s_block1 = slice_to_aligned(bucket.get_unchecked(offset_sub1..offset_sub1 + LAYER_1_SIZE));
-        let s_block2 = slice_to_aligned(bucket.get_unchecked(offset_sub2..offset_sub2 + LAYER_1_SIZE));
-
-        let mut registers: [Vector16; 16] = [Vector16::zero(); 16];
-        for i in 0..LAYER_1_SIZE / UNROLL {
-            let unroll_offset = i * UNROLL;
-
-            for (r_idx, reg) in registers.iter_mut().enumerate() {
-                *reg = Vector16::load_at(input, unroll_offset + r_idx * Vector16::COUNT);
-            }
-
-            for (r_idx, reg) in registers.iter_mut().enumerate() {
-                let w_sub = Vector16::load_at(s_block1, unroll_offset + r_idx * Vector16::COUNT);
-                *reg = Vector16::sub(*reg, w_sub);
-            }
-
-            for (r_idx, reg) in registers.iter_mut().enumerate() {
-                let w_sub = Vector16::load_at(s_block2, unroll_offset + r_idx * Vector16::COUNT);
-                *reg = Vector16::sub(*reg, w_sub);
-            }
-
-            for (r_idx, reg) in registers.iter_mut().enumerate() {
-                let w_add = Vector16::load_at(a_block, unroll_offset + r_idx * Vector16::COUNT);
-                *reg = Vector16::add(*reg, w_add);
-            }
-
-            for (r_idx, reg) in registers.iter().enumerate() {
-                Vector16::store_at(output, *reg, unroll_offset + r_idx * Vector16::COUNT);
-            }
+    let a_block = unsafe { slice_to_aligned(bucket.get_unchecked(offset_add..offset_add + LAYER_1_SIZE)) };
+    let s_block1 = unsafe { slice_to_aligned(bucket.get_unchecked(offset_sub1..offset_sub1 + LAYER_1_SIZE)) };
+    let s_block2 = unsafe { slice_to_aligned(bucket.get_unchecked(offset_sub2..offset_sub2 + LAYER_1_SIZE)) };
+    for i in 0..LAYER_1_SIZE / Vector16::COUNT {
+        unsafe {
+            let x = Vector16::load_at(input, i * Vector16::COUNT);
+            let w_sub1 = Vector16::load_at(s_block1, i * Vector16::COUNT);
+            let w_sub2 = Vector16::load_at(s_block2, i * Vector16::COUNT);
+            let w_add = Vector16::load_at(a_block, i * Vector16::COUNT);
+            let t = Vector16::sub(x, w_sub1);
+            let t = Vector16::sub(t, w_sub2);
+            let t = Vector16::add(t, w_add);
+            Vector16::store_at(output, t, i * Vector16::COUNT);
         }
     }
 }
@@ -519,43 +485,22 @@ pub fn vector_add2_sub2(
     let offset_add2 = feature_idx_add2.index() * LAYER_1_SIZE;
     let offset_sub1 = feature_idx_sub1.index() * LAYER_1_SIZE;
     let offset_sub2 = feature_idx_sub2.index() * LAYER_1_SIZE;
-    unsafe {
-        let a_block1 = slice_to_aligned(bucket.get_unchecked(offset_add1..offset_add1 + LAYER_1_SIZE));
-        let a_block2 = slice_to_aligned(bucket.get_unchecked(offset_add2..offset_add2 + LAYER_1_SIZE));
-        let s_block1 = slice_to_aligned(bucket.get_unchecked(offset_sub1..offset_sub1 + LAYER_1_SIZE));
-        let s_block2 = slice_to_aligned(bucket.get_unchecked(offset_sub2..offset_sub2 + LAYER_1_SIZE));
-
-        let mut registers: [Vector16; 16] = [Vector16::zero(); 16];
-        for i in 0..LAYER_1_SIZE / UNROLL {
-            let unroll_offset = i * UNROLL;
-
-            for (r_idx, reg) in registers.iter_mut().enumerate() {
-                *reg = Vector16::load_at(input, unroll_offset + r_idx * Vector16::COUNT);
-            }
-
-            for (r_idx, reg) in registers.iter_mut().enumerate() {
-                let w_sub = Vector16::load_at(s_block1, unroll_offset + r_idx * Vector16::COUNT);
-                *reg = Vector16::sub(*reg, w_sub);
-            }
-
-            for (r_idx, reg) in registers.iter_mut().enumerate() {
-                let w_sub = Vector16::load_at(s_block2, unroll_offset + r_idx * Vector16::COUNT);
-                *reg = Vector16::sub(*reg, w_sub);
-            }
-
-            for (r_idx, reg) in registers.iter_mut().enumerate() {
-                let w_add = Vector16::load_at(a_block1, unroll_offset + r_idx * Vector16::COUNT);
-                *reg = Vector16::add(*reg, w_add);
-            }
-
-            for (r_idx, reg) in registers.iter_mut().enumerate() {
-                let w_add = Vector16::load_at(a_block2, unroll_offset + r_idx * Vector16::COUNT);
-                *reg = Vector16::add(*reg, w_add);
-            }
-
-            for (r_idx, reg) in registers.iter().enumerate() {
-                Vector16::store_at(output, *reg, unroll_offset + r_idx * Vector16::COUNT);
-            }
+    let a_block1 = unsafe { slice_to_aligned(bucket.get_unchecked(offset_add1..offset_add1 + LAYER_1_SIZE)) };
+    let a_block2 = unsafe { slice_to_aligned(bucket.get_unchecked(offset_add2..offset_add2 + LAYER_1_SIZE)) };
+    let s_block1 = unsafe { slice_to_aligned(bucket.get_unchecked(offset_sub1..offset_sub1 + LAYER_1_SIZE)) };
+    let s_block2 = unsafe { slice_to_aligned(bucket.get_unchecked(offset_sub2..offset_sub2 + LAYER_1_SIZE)) };
+    for i in 0..LAYER_1_SIZE / Vector16::COUNT {
+        unsafe {
+            let x = Vector16::load_at(input, i * Vector16::COUNT);
+            let w_sub1 = Vector16::load_at(s_block1, i * Vector16::COUNT);
+            let w_sub2 = Vector16::load_at(s_block2, i * Vector16::COUNT);
+            let w_add1 = Vector16::load_at(a_block1, i * Vector16::COUNT);
+            let w_add2 = Vector16::load_at(a_block2, i * Vector16::COUNT);
+            let t = Vector16::sub(x, w_sub1);
+            let t = Vector16::sub(t, w_sub2);
+            let t = Vector16::add(t, w_add1);
+            let t = Vector16::add(t, w_add2);
+            Vector16::store_at(output, t, i * Vector16::COUNT);
         }
     }
 }


### PR DESCRIPTION
~3.3% speedup on my laptop.
On a server:
```
      fast-accumulator-refresh      |               master               |
        mu              sigma       |        mu              sigma       |   Sp(1)/Sp(2)      3*sigma   
------------------------------------+------------------------------------+------------------------------------
        875680.000             0.000|        856784.000             0.000|       2.205 %  +/-  0.000 %
        874073.500          2271.934|        858979.000          3104.199|       1.758 %  +/-  1.897 %
        874505.333          1772.084|        859293.667          2261.652|       1.771 %  +/-  1.343 %
        874809.000          1569.196|        860594.250          3190.002|       1.653 %  +/-  1.306 %
        874993.600          1420.270|        859987.200          3078.089|       1.746 %  +/-  1.292 %
        875436.333          1670.273|        860233.000          2818.193|       1.768 %  +/-  1.167 %
        874745.000          2381.267|        860819.571          3004.492|       1.619 %  +/-  1.593 %
        874959.875          2286.863|        860203.875          3281.777|       1.717 %  +/-  1.693 %
        875920.778          3589.712|        860183.667          3070.420|       1.831 %  +/-  1.887 %
        876069.500          3416.933|        860624.100          3212.444|       1.796 %  +/-  1.809 %
        875946.455          3267.175|        860961.545          3246.595|       1.742 %  +/-  1.799 %
        875267.917          3902.434|        860751.667          3179.741|       1.688 %  +/-  1.806 %
        875390.308          3762.266|        860688.231          3052.950|       1.709 %  +/-  1.745 %
        875808.143          3938.278|        860462.286          3052.582|       1.785 %  +/-  1.878 %
        875996.267          3864.328|        860348.733          2974.236|       1.820 %  +/-  1.855 %
        876068.875          3744.576|        860426.125          2890.013|       1.819 %  +/-  1.792 %
        875892.529          3697.857|        860592.118          2880.725|       1.779 %  +/-  1.805 %
        876007.611          3620.521|        860595.111          2794.742|       1.792 %  +/-  1.759 %
        875853.368          3582.173|        860657.211          2729.457|       1.767 %  +/-  1.741 %
        875824.600          3489.004|        860798.800          2731.077|       1.747 %  +/-  1.716 %
        876040.714          3541.935|        860566.857          2866.285|       1.800 %  +/-  1.823 %
        876069.636          3459.236|        860630.545          2813.114|       1.795 %  +/-  1.780 %
        875711.087          3791.994|        860632.957          2748.460|       1.753 %  +/-  1.841 %
        875666.292          3715.130|        860770.000          2770.621|       1.732 %  +/-  1.828 %
        875729.520          3650.623|        860791.440          2714.403|       1.737 %  +/-  1.791 %
        875801.538          3595.667|        861040.846          2947.974|       1.716 %  +/-  1.784 %
        875787.296          3526.618|        861078.148          2897.218|       1.710 %  +/-  1.752 %
        875829.857          3468.014|        861098.036          2845.006|       1.712 %  +/-  1.719 %
        875981.828          3502.476|        861030.207          2817.518|       1.738 %  +/-  1.739 %
        875870.567          3495.096|        861160.867          2859.516|       1.710 %  +/-  1.770 %
        875826.935          3444.927|        861306.903          2926.670|       1.687 %  +/-  1.780 %
        875792.719          3394.431|        861288.062          2881.050|       1.685 %  +/-  1.751 %
        875796.727          3341.051|        861457.485          2998.048|       1.666 %  +/-  1.756 %
        875897.441          3342.040|        861491.000          2958.735|       1.674 %  +/-  1.734 %
        875897.000          3292.527|        861593.371          2977.152|       1.662 %  +/-  1.722 %
        875784.222          3314.947|        861713.889          3022.097|       1.634 %  +/-  1.767 %
        875600.703          3453.950|        861697.595          2981.476|       1.615 %  +/-  1.778 %
        875494.711          3469.041|        861583.526          3023.804|       1.616 %  +/-  1.754 %
```