### PR TITLE
negative extensions in cut-nodes

### DIFF
--- a/IDEAS.txt
+++ b/IDEAS.txt
@@ -19,7 +19,7 @@ MINOR:
 - probcut tinkering (SF in-check trick)
 - futility tinkering
 - use history for more things
-- iir tinkering (ttmove, excluded move, non-PV nodes, other fiddling)
+- iir tinkering (ttmove, (((excluded move))), non-PV nodes, other fiddling)
 - iid tinkering (ttmove, excluded move)
 - look for bad zero-init of arrays.
 - skip tt entry reload in the store() function.

--- a/src/nnue/network.rs
+++ b/src/nnue/network.rs
@@ -440,12 +440,7 @@ impl NNUEState {
         let black_king = board.king_sq(Colour::Black);
 
         loop {
-            self.materialise_new_acc_from(
-                white_king,
-                black_king,
-                pov_update,
-                curr_index + 1,
-            );
+            self.materialise_new_acc_from(white_king, black_king, pov_update, curr_index + 1);
 
             self.accumulators[curr_index + 1].correct[view] = true;
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -994,6 +994,7 @@ impl Board {
                         extension = ONE_PLY;
                     }
                 } else if cut_node {
+                    // produce a strong negative extension if we didn't fail low on a cut-node.
                     extension = -ONE_PLY * 2;
                 } else if tt_value >= beta || tt_value <= alpha {
                     // the tt_value >= beta condition is a sort of "light multi-cut"

--- a/src/search.rs
+++ b/src/search.rs
@@ -993,6 +993,8 @@ impl Board {
                         // normal singular extension
                         extension = ONE_PLY;
                     }
+                } else if cut_node {
+                    extension = -ONE_PLY * 2;
                 } else if tt_value >= beta || tt_value <= alpha {
                     // the tt_value >= beta condition is a sort of "light multi-cut"
                     // the tt_value <= alpha condition is from Weiss (https://github.com/TerjeKir/weiss/compare/2a7b4ed0...effa8349/).


### PR DESCRIPTION
```
Elo   | 1.78 +- 1.42 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 3.00]
Games | N: 64926 W: 15514 L: 15182 D: 34230
Penta | [372, 7491, 16422, 7789, 389]
https://chess.swehosting.se/test/6795/
```