### PR TITLE
Don't perform cutnode IIR when in singular search.

### DIFF
--- a/IDEAS.txt
+++ b/IDEAS.txt
@@ -19,7 +19,11 @@ MINOR:
 - probcut tinkering (SF in-check trick)
 - futility tinkering
 - use history for more things
-- iir tinkering (ttmove, (((excluded move))), non-PV nodes, other fiddling)
+- iir tinkering (ttmove, non-PV nodes, other fiddling)
 - iid tinkering (ttmove, excluded move)
 - look for bad zero-init of arrays.
 - skip tt entry reload in the store() function.
+- pv update only in PV nodes.
+- https://chess.swehosting.se/test/6671/
+- triple extensions
+- tt clusters

--- a/src/search.rs
+++ b/src/search.rs
@@ -782,7 +782,7 @@ impl Board {
         }
 
         // cutnode-based TT reduction.
-        if cut_node && /* excluded.is_none() && */ tt_move.is_none() {
+        if cut_node && excluded.is_none() && tt_move.is_none() {
             depth -= i32::from(depth >= info.conf.tt_reduction_depth * 2);
         }
 


### PR DESCRIPTION
```
Elo   | 0.69 +- 2.57 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 18748 W: 4414 L: 4377 D: 9957
Penta | [106, 2080, 4952, 2143, 93]
https://chess.swehosting.se/test/6803/
```