### PR TITLE
Dynamically correct the NN evaluation using whole-tree statistics.

### DIFF
--- a/src/board/validation.rs
+++ b/src/board/validation.rs
@@ -39,8 +39,8 @@ impl Board {
         if !(self.side == Colour::White || self.side == Colour::Black) {
             return Err(format!("side is corrupt: expected WHITE or BLACK, got {:?}", self.side));
         }
-        if self.generate_pos_key() != self.key {
-            return Err(format!("key is corrupt: expected {:?}, got {:?}", self.generate_pos_key(), self.key));
+        if self.generate_pos_key().0 != self.key {
+            return Err(format!("key is corrupt: expected {:?}, got {:?}", self.generate_pos_key().0, self.key));
         }
 
         if !(self.ep_sq.is_none()

--- a/src/perft.rs
+++ b/src/perft.rs
@@ -263,15 +263,15 @@ mod tests {
         let e4 = Move::new(Square::E2, Square::E4);
         let bitboard_before = pos.pieces;
         println!("{bitboard_before}");
-        let hashkey_before = pos.hashkey();
+        let hashkey_before = pos.zobrist_key();
         pos.make_move_simple(e4);
         assert_ne!(pos.pieces, bitboard_before);
         println!("{bb_after}", bb_after = pos.pieces);
-        assert_ne!(pos.hashkey(), hashkey_before);
+        assert_ne!(pos.zobrist_key(), hashkey_before);
         pos.unmake_move_base();
         assert_eq!(pos.pieces, bitboard_before);
         println!("{bb_returned}", bb_returned = pos.pieces);
-        assert_eq!(pos.hashkey(), hashkey_before);
+        assert_eq!(pos.zobrist_key(), hashkey_before);
     }
 
     #[test]
@@ -283,14 +283,14 @@ mod tests {
         let exd5 = Move::new(Square::E4, Square::D5);
         let bitboard_before = pos.pieces;
         println!("{bitboard_before}");
-        let hashkey_before = pos.hashkey();
+        let hashkey_before = pos.zobrist_key();
         pos.make_move_simple(exd5);
         assert_ne!(pos.pieces, bitboard_before);
         println!("{bb_after}", bb_after = pos.pieces);
-        assert_ne!(pos.hashkey(), hashkey_before);
+        assert_ne!(pos.zobrist_key(), hashkey_before);
         pos.unmake_move_base();
         assert_eq!(pos.pieces, bitboard_before);
         println!("{bb_returned}", bb_returned = pos.pieces);
-        assert_eq!(pos.hashkey(), hashkey_before);
+        assert_eq!(pos.zobrist_key(), hashkey_before);
     }
 }

--- a/src/threadlocal.rs
+++ b/src/threadlocal.rs
@@ -3,7 +3,7 @@ use std::array;
 use crate::{
     board::Board,
     chessmove::Move,
-    historytable::{CaptureHistoryTable, DoubleHistoryTable, MoveTable, ThreatsHistoryTable},
+    historytable::{CaptureHistoryTable, CorrectionHistoryTable, DoubleHistoryTable, MoveTable, ThreatsHistoryTable},
     nnue,
     piece::Colour,
     search::pv::PVariation,
@@ -27,6 +27,7 @@ pub struct ThreadData<'a> {
     pub cont_hists: [Box<DoubleHistoryTable>; 2],
     pub killer_move_table: [[Option<Move>; 2]; MAX_PLY + 1],
     pub counter_move_table: MoveTable,
+    pub correction_history: Box<CorrectionHistoryTable>,
 
     pub thread_id: usize,
 
@@ -54,6 +55,7 @@ impl<'a> ThreadData<'a> {
             cont_hists: [(); 2].map(|()| DoubleHistoryTable::boxed()),
             killer_move_table: [[None; 2]; MAX_PLY + 1],
             counter_move_table: MoveTable::new(),
+            correction_history: CorrectionHistoryTable::boxed(),
             thread_id,
             pvs: vec![PVariation::default(); MAX_PLY],
             completed: 0,
@@ -85,6 +87,7 @@ impl<'a> ThreadData<'a> {
         self.cont_hists.iter_mut().for_each(|h| h.clear());
         self.killer_move_table.fill([None; 2]);
         self.counter_move_table.clear();
+        self.correction_history.clear();
         self.depth = 0;
         self.completed = 0;
         self.pvs.fill(PVariation::default());
@@ -96,6 +99,7 @@ impl<'a> ThreadData<'a> {
         self.cont_hists.iter_mut().for_each(|h| h.age_entries());
         self.killer_move_table.fill([None; 2]);
         self.counter_move_table.clear();
+        self.correction_history.age_entries();
         self.depth = 0;
         self.completed = 0;
         self.pvs.fill(PVariation::default());

--- a/src/util.rs
+++ b/src/util.rs
@@ -344,6 +344,7 @@ pub struct Undo {
     pub bitboard: BitBoard,
     pub piece_array: [Option<Piece>; 64],
     pub key: u64,
+    pub pawn_key: u64,
 }
 
 impl Default for Undo {
@@ -357,6 +358,7 @@ impl Default for Undo {
             bitboard: BitBoard::NULL,
             piece_array: [None; 64],
             key: 0,
+            pawn_key: 0,
         }
     }
 }


### PR DESCRIPTION
```
Elo   | 12.25 +- 4.84 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 5448 W: 1362 L: 1170 D: 2916
Penta | [21, 557, 1393, 715, 38]
https://chess.swehosting.se/test/7022/
```