### PR TITLE
Make UCI `go` command more well-behaved.

### DIFF
--- a/src/historytable.rs
+++ b/src/historytable.rs
@@ -4,7 +4,7 @@ use crate::{
     util::{depth::Depth, Square, BOARD_N_SQUARES},
 };
 
-const AGEING_DIVISOR: i16 = 2;
+// const AGEING_DIVISOR: i16 = 2;
 
 const fn history_bonus(depth: Depth) -> i32 {
     let depth = depth.round();
@@ -48,10 +48,10 @@ impl HistoryTable {
         }
     }
 
-    pub fn age_entries(&mut self) {
-        debug_assert!(!self.table.is_empty());
-        self.table.iter_mut().flatten().for_each(|x| *x /= AGEING_DIVISOR);
-    }
+    // pub fn age_entries(&mut self) {
+    //     debug_assert!(!self.table.is_empty());
+    //     self.table.iter_mut().flatten().for_each(|x| *x /= AGEING_DIVISOR);
+    // }
 
     pub fn get(&self, piece: Piece, sq: Square) -> i16 {
         self.table[piece][sq]
@@ -80,10 +80,10 @@ impl ThreatsHistoryTable {
         self.table.iter_mut().flatten().for_each(HistoryTable::clear);
     }
 
-    pub fn age_entries(&mut self) {
-        debug_assert!(!self.table.is_empty());
-        self.table.iter_mut().flatten().for_each(HistoryTable::age_entries);
-    }
+    // pub fn age_entries(&mut self) {
+    //     debug_assert!(!self.table.is_empty());
+    //     self.table.iter_mut().flatten().for_each(HistoryTable::age_entries);
+    // }
 
     pub fn get(&self, piece: Piece, sq: Square, threat_from: bool, threat_to: bool) -> i16 {
         self.table[usize::from(threat_from)][usize::from(threat_to)].get(piece, sq)
@@ -120,10 +120,10 @@ impl CaptureHistoryTable {
         self.table.iter_mut().for_each(HistoryTable::clear);
     }
 
-    pub fn age_entries(&mut self) {
-        debug_assert!(!self.table.is_empty());
-        self.table.iter_mut().for_each(HistoryTable::age_entries);
-    }
+    // pub fn age_entries(&mut self) {
+    //     debug_assert!(!self.table.is_empty());
+    //     self.table.iter_mut().for_each(HistoryTable::age_entries);
+    // }
 
     pub fn get(&self, piece: Piece, sq: Square, capture: PieceType) -> i16 {
         self.table[capture].get(piece, sq)
@@ -167,10 +167,10 @@ impl DoubleHistoryTable {
         self.table.iter_mut().flatten().for_each(HistoryTable::clear);
     }
 
-    pub fn age_entries(&mut self) {
-        debug_assert!(!self.table.is_empty());
-        self.table.iter_mut().flatten().for_each(HistoryTable::age_entries);
-    }
+    // pub fn age_entries(&mut self) {
+    //     debug_assert!(!self.table.is_empty());
+    //     self.table.iter_mut().flatten().for_each(HistoryTable::age_entries);
+    // }
 
     pub fn get_index_mut(&mut self, index: ContHistIndex) -> &mut HistoryTable {
         &mut self.table[index.piece][index.square]
@@ -226,9 +226,9 @@ impl CorrectionHistoryTable {
         }
     }
 
-    pub fn age_entries(&mut self) {
-        self.table.iter_mut().flatten().for_each(|x| *x /= i32::from(AGEING_DIVISOR));
-    }
+    // pub fn age_entries(&mut self) {
+    //     self.table.iter_mut().flatten().for_each(|x| *x /= i32::from(AGEING_DIVISOR));
+    // }
 
     pub fn clear(&mut self) {
         self.table.iter_mut().for_each(|t| t.fill(0));

--- a/src/historytable.rs
+++ b/src/historytable.rs
@@ -4,7 +4,7 @@ use crate::{
     util::{depth::Depth, Square, BOARD_N_SQUARES},
 };
 
-// const AGEING_DIVISOR: i16 = 2;
+const AGEING_DIVISOR: i16 = 2;
 
 const fn history_bonus(depth: Depth) -> i32 {
     let depth = depth.round();
@@ -48,10 +48,10 @@ impl HistoryTable {
         }
     }
 
-    // pub fn age_entries(&mut self) {
-    //     debug_assert!(!self.table.is_empty());
-    //     self.table.iter_mut().flatten().for_each(|x| *x /= AGEING_DIVISOR);
-    // }
+    pub fn age_entries(&mut self) {
+        debug_assert!(!self.table.is_empty());
+        self.table.iter_mut().flatten().for_each(|x| *x /= AGEING_DIVISOR);
+    }
 
     pub fn get(&self, piece: Piece, sq: Square) -> i16 {
         self.table[piece][sq]
@@ -80,10 +80,10 @@ impl ThreatsHistoryTable {
         self.table.iter_mut().flatten().for_each(HistoryTable::clear);
     }
 
-    // pub fn age_entries(&mut self) {
-    //     debug_assert!(!self.table.is_empty());
-    //     self.table.iter_mut().flatten().for_each(HistoryTable::age_entries);
-    // }
+    pub fn age_entries(&mut self) {
+        debug_assert!(!self.table.is_empty());
+        self.table.iter_mut().flatten().for_each(HistoryTable::age_entries);
+    }
 
     pub fn get(&self, piece: Piece, sq: Square, threat_from: bool, threat_to: bool) -> i16 {
         self.table[usize::from(threat_from)][usize::from(threat_to)].get(piece, sq)
@@ -120,10 +120,10 @@ impl CaptureHistoryTable {
         self.table.iter_mut().for_each(HistoryTable::clear);
     }
 
-    // pub fn age_entries(&mut self) {
-    //     debug_assert!(!self.table.is_empty());
-    //     self.table.iter_mut().for_each(HistoryTable::age_entries);
-    // }
+    pub fn age_entries(&mut self) {
+        debug_assert!(!self.table.is_empty());
+        self.table.iter_mut().for_each(HistoryTable::age_entries);
+    }
 
     pub fn get(&self, piece: Piece, sq: Square, capture: PieceType) -> i16 {
         self.table[capture].get(piece, sq)
@@ -167,10 +167,10 @@ impl DoubleHistoryTable {
         self.table.iter_mut().flatten().for_each(HistoryTable::clear);
     }
 
-    // pub fn age_entries(&mut self) {
-    //     debug_assert!(!self.table.is_empty());
-    //     self.table.iter_mut().flatten().for_each(HistoryTable::age_entries);
-    // }
+    pub fn age_entries(&mut self) {
+        debug_assert!(!self.table.is_empty());
+        self.table.iter_mut().flatten().for_each(HistoryTable::age_entries);
+    }
 
     pub fn get_index_mut(&mut self, index: ContHistIndex) -> &mut HistoryTable {
         &mut self.table[index.piece][index.square]
@@ -226,9 +226,9 @@ impl CorrectionHistoryTable {
         }
     }
 
-    // pub fn age_entries(&mut self) {
-    //     self.table.iter_mut().flatten().for_each(|x| *x /= i32::from(AGEING_DIVISOR));
-    // }
+    pub fn age_entries(&mut self) {
+        self.table.iter_mut().flatten().for_each(|x| *x /= i32::from(AGEING_DIVISOR));
+    }
 
     pub fn clear(&mut self) {
         self.table.iter_mut().for_each(|t| t.fill(0));

--- a/src/search.rs
+++ b/src/search.rs
@@ -156,7 +156,9 @@ impl Board {
         thread_headers: &mut [ThreadData],
         tt: TTView,
     ) -> (i32, Option<Move>) {
-        set_up_for_search(self, info, thread_headers);
+        self.zero_height();
+        info.set_up_for_search();
+        TB_HITS.store(0, Ordering::Relaxed);
 
         let legal_moves = self.legal_moves();
         if legal_moves.is_empty() {
@@ -190,20 +192,25 @@ impl Board {
 
         let global_stopped = info.stopped;
         assert!(!global_stopped.load(Ordering::SeqCst), "global_stopped must be false");
+
         // start search threads:
         let (t1, rest) = thread_headers.split_first_mut().unwrap();
-        let board_copy = self.clone();
-        let info_copy = info.clone();
-        let mut board_info_copies = rest.iter().map(|_| (board_copy.clone(), info_copy.clone())).collect::<Vec<_>>();
-
         thread::scope(|s| {
             s.spawn(|| {
-                self.iterative_deepening::<MainThread>(info, t1);
+                // copy data into thread
+                let mut board = self.clone();
+                let mut info = info.clone();
+                t1.set_up_for_search(&board);
+                board.iterative_deepening::<MainThread>(&mut info, t1);
                 global_stopped.store(true, Ordering::SeqCst);
             });
-            for (t, (board, info)) in rest.iter_mut().zip(&mut board_info_copies) {
+            for t in rest.iter_mut() {
                 s.spawn(|| {
-                    board.iterative_deepening::<HelperThread>(info, t);
+                    // copy data into thread
+                    let mut board = self.clone();
+                    let mut info = info.clone();
+                    t.set_up_for_search(&board);
+                    board.iterative_deepening::<HelperThread>(&mut info, t);
                 });
             }
         });
@@ -1555,11 +1562,4 @@ impl AspirationWindow {
     }
 }
 
-fn set_up_for_search(board: &mut Board, info: &mut SearchInfo, thread_headers: &mut [ThreadData]) {
-    board.zero_height();
-    info.set_up_for_search();
-    for td in thread_headers {
-        td.set_up_for_search(board);
-    }
-    TB_HITS.store(0, Ordering::Relaxed);
-}
+

--- a/src/search.rs
+++ b/src/search.rs
@@ -220,8 +220,8 @@ impl Board {
         let pv = best_thread.pv().clone();
         let best_move = pv.moves().first().copied().unwrap_or_else(|| self.default_move(&thread_headers[0]));
 
-        if info.print_to_stdout && info.skip_print() {
-            // we haven't printed any ID logging yet, so give one as we leave search.
+        if info.print_to_stdout {
+            // always give a final info log before ending search
             let nodes = info.nodes.get_global();
             readout_info(self, Bound::Exact, &pv, depth_achieved, info, tt, nodes, true);
         }

--- a/src/search/pv.rs
+++ b/src/search/pv.rs
@@ -14,17 +14,23 @@ pub struct PVariation {
 
 impl Default for PVariation {
     fn default() -> Self {
-        Self { score: 0, moves: ArrayVec::new() }
+        Self::EMPTY
     }
 }
 
 impl PVariation {
+    const EMPTY: Self = Self { score: 0, moves: ArrayVec::new_const() };
+
     pub fn moves(&self) -> &[Move] {
         &self.moves
     }
 
     pub const fn score(&self) -> i32 {
         self.score
+    }
+
+    pub const fn default_const() -> Self {
+        Self::EMPTY
     }
 
     pub(crate) fn load_from(&mut self, m: Move, rest: &Self) {

--- a/src/searchinfo.rs
+++ b/src/searchinfo.rs
@@ -93,7 +93,9 @@ impl<'a> SearchInfo<'a> {
     pub fn set_up_for_search(&mut self) {
         self.stopped.store(false, Ordering::SeqCst);
         self.nodes.reset();
-        self.root_move_nodes = [[0; 64]; 64];
+        for rmnc in self.root_move_nodes.iter_mut().flatten() {
+            *rmnc = 0;
+        }
         self.time_manager.reset_for_id(&self.conf);
         #[cfg(feature = "stats")]
         {

--- a/src/threadlocal.rs
+++ b/src/threadlocal.rs
@@ -87,19 +87,19 @@ impl<'a> ThreadData<'a> {
         self.main_history.clear();
         self.tactical_history.clear();
         self.cont_hists.iter_mut().for_each(|h| h.clear());
+        self.correction_history.clear();
         self.killer_move_table.fill([None; 2]);
         self.counter_move_table.clear();
-        self.correction_history.clear();
         self.depth = 0;
         self.completed = 0;
         self.pvs = Self::EMPTY_PV_TABLE;
     }
 
     pub fn set_up_for_search(&mut self, board: &Board) {
-        // self.main_history.age_entries();
-        // self.tactical_history.age_entries();
-        // self.cont_hists.iter_mut().for_each(|h| h.age_entries());
-        // self.correction_history.age_entries();
+        self.main_history.age_entries();
+        self.tactical_history.age_entries();
+        self.cont_hists.iter_mut().for_each(|h| h.age_entries());
+        self.correction_history.age_entries();
         self.killer_move_table.fill([None; 2]);
         self.counter_move_table.clear();
         self.depth = 0;


### PR DESCRIPTION
```
Elo   | 0.11 +- 2.03 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 26424 W: 6264 L: 6256 D: 13904
Penta | [114, 2664, 7625, 2718, 91]
https://chess.swehosting.se/test/7221/
```

This patch done on the [recommendation of Andrew Grant](https://github.com/AndyGrant/Ethereal/issues/214).