### PR TITLE
Unify continuation history tables.

### DIFF
--- a/src/board/history.rs
+++ b/src/board/history.rs
@@ -102,7 +102,7 @@ impl ThreadData<'_> {
             Some(Undo { cont_hist_index: Some(cont_hist_index), .. }) => *cont_hist_index,
             _ => return,
         };
-        let cmh_block = self.cont_hist.get_index_mut(conthist_index);
+        let cmh_block = self.continuation_history.get_index_mut(conthist_index);
         for &m in moves_to_adjust {
             let to = m.history_to_square();
             let piece = pos.moved_piece(m).unwrap();
@@ -120,7 +120,7 @@ impl ThreadData<'_> {
             Some(Undo { cont_hist_index: Some(cont_hist_index), .. }) => *cont_hist_index,
             _ => return,
         };
-        let cmh_block = self.cont_hist.get_index(conthist_index);
+        let cmh_block = self.continuation_history.get_index(conthist_index);
         for m in ms {
             let to = m.mov.history_to_square();
             let piece = pos.moved_piece(m.mov).unwrap();
@@ -138,7 +138,7 @@ impl ThreadData<'_> {
             Some(Undo { cont_hist_index: Some(cont_hist_index), .. }) => *cont_hist_index,
             _ => return 0,
         };
-        let cmh_block = self.cont_hist.get_index(conthist_index);
+        let cmh_block = self.continuation_history.get_index(conthist_index);
         let to = m.history_to_square();
         let piece = pos.moved_piece(m).unwrap();
         i32::from(cmh_block.get(piece, to))

--- a/src/board/history.rs
+++ b/src/board/history.rs
@@ -102,8 +102,7 @@ impl ThreadData<'_> {
             Some(Undo { cont_hist_index: Some(cont_hist_index), .. }) => *cont_hist_index,
             _ => return,
         };
-        let table = self.cont_hists[index].as_mut();
-        let cmh_block = table.get_index_mut(conthist_index);
+        let cmh_block = self.cont_hist.get_index_mut(conthist_index);
         for &m in moves_to_adjust {
             let to = m.history_to_square();
             let piece = pos.moved_piece(m).unwrap();
@@ -121,8 +120,7 @@ impl ThreadData<'_> {
             Some(Undo { cont_hist_index: Some(cont_hist_index), .. }) => *cont_hist_index,
             _ => return,
         };
-        let table = self.cont_hists[index].as_ref();
-        let cmh_block = table.get_index(conthist_index);
+        let cmh_block = self.cont_hist.get_index(conthist_index);
         for m in ms {
             let to = m.mov.history_to_square();
             let piece = pos.moved_piece(m.mov).unwrap();
@@ -140,8 +138,7 @@ impl ThreadData<'_> {
             Some(Undo { cont_hist_index: Some(cont_hist_index), .. }) => *cont_hist_index,
             _ => return 0,
         };
-        let table = self.cont_hists[index].as_ref();
-        let cmh_block = table.get_index(conthist_index);
+        let cmh_block = self.cont_hist.get_index(conthist_index);
         let to = m.history_to_square();
         let piece = pos.moved_piece(m).unwrap();
         i32::from(cmh_block.get(piece, to))

--- a/src/threadlocal.rs
+++ b/src/threadlocal.rs
@@ -23,7 +23,7 @@ pub struct ThreadData<'a> {
 
     pub main_history: ThreatsHistoryTable,
     pub tactical_history: Box<CaptureHistoryTable>,
-    pub cont_hist: Box<DoubleHistoryTable>,
+    pub continuation_history: Box<DoubleHistoryTable>,
     pub killer_move_table: [[Option<Move>; 2]; MAX_PLY + 1],
     pub counter_move_table: MoveTable,
     pub correction_history: Box<CorrectionHistoryTable>,
@@ -52,7 +52,7 @@ impl<'a> ThreadData<'a> {
             nnue: nnue::network::NNUEState::new(board),
             main_history: ThreatsHistoryTable::new(),
             tactical_history: CaptureHistoryTable::boxed(),
-            cont_hist: DoubleHistoryTable::boxed(),
+            continuation_history: DoubleHistoryTable::boxed(),
             killer_move_table: [[None; 2]; MAX_PLY + 1],
             counter_move_table: MoveTable::new(),
             correction_history: CorrectionHistoryTable::boxed(),
@@ -84,7 +84,7 @@ impl<'a> ThreadData<'a> {
     pub fn clear_tables(&mut self) {
         self.main_history.clear();
         self.tactical_history.clear();
-        self.cont_hist.clear();
+        self.continuation_history.clear();
         self.correction_history.clear();
         self.killer_move_table.fill([None; 2]);
         self.counter_move_table.clear();
@@ -96,7 +96,7 @@ impl<'a> ThreadData<'a> {
     pub fn set_up_for_search(&mut self, board: &Board) {
         self.main_history.age_entries();
         self.tactical_history.age_entries();
-        self.cont_hist.age_entries();
+        self.continuation_history.age_entries();
         self.correction_history.age_entries();
         self.killer_move_table.fill([None; 2]);
         self.counter_move_table.clear();

--- a/src/threadlocal.rs
+++ b/src/threadlocal.rs
@@ -23,7 +23,7 @@ pub struct ThreadData<'a> {
 
     pub main_history: ThreatsHistoryTable,
     pub tactical_history: Box<CaptureHistoryTable>,
-    pub cont_hists: [Box<DoubleHistoryTable>; 2],
+    pub cont_hist: Box<DoubleHistoryTable>,
     pub killer_move_table: [[Option<Move>; 2]; MAX_PLY + 1],
     pub counter_move_table: MoveTable,
     pub correction_history: Box<CorrectionHistoryTable>,
@@ -52,7 +52,7 @@ impl<'a> ThreadData<'a> {
             nnue: nnue::network::NNUEState::new(board),
             main_history: ThreatsHistoryTable::new(),
             tactical_history: CaptureHistoryTable::boxed(),
-            cont_hists: [(); 2].map(|()| DoubleHistoryTable::boxed()),
+            cont_hist: DoubleHistoryTable::boxed(),
             killer_move_table: [[None; 2]; MAX_PLY + 1],
             counter_move_table: MoveTable::new(),
             correction_history: CorrectionHistoryTable::boxed(),
@@ -84,7 +84,7 @@ impl<'a> ThreadData<'a> {
     pub fn clear_tables(&mut self) {
         self.main_history.clear();
         self.tactical_history.clear();
-        self.cont_hists.iter_mut().for_each(|h| h.clear());
+        self.cont_hist.clear();
         self.correction_history.clear();
         self.killer_move_table.fill([None; 2]);
         self.counter_move_table.clear();
@@ -96,7 +96,7 @@ impl<'a> ThreadData<'a> {
     pub fn set_up_for_search(&mut self, board: &Board) {
         self.main_history.age_entries();
         self.tactical_history.age_entries();
-        self.cont_hists.iter_mut().for_each(|h| h.age_entries());
+        self.cont_hist.age_entries();
         self.correction_history.age_entries();
         self.killer_move_table.fill([None; 2]);
         self.counter_move_table.clear();


### PR DESCRIPTION
```
Elo   | 1.90 +- 3.12 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 11152 W: 2688 L: 2627 D: 5837
Penta | [42, 1109, 3215, 1166, 44]
https://chess.swehosting.se/test/7295/
```