### PR TITLE
New network, id `semiotic`.

### DIFF
--- a/src/board/evaluation.rs
+++ b/src/board/evaluation.rs
@@ -1,12 +1,7 @@
 // The granularity of evaluation in this engine is in centipawns.
 
 use crate::{
-    board::Board,
-    chessmove::Move,
-    piece::{Colour, Piece, PieceType},
-    search::draw_score,
-    threadlocal::ThreadData,
-    util::MAX_DEPTH,
+    board::Board, chessmove::Move, nnue::network, piece::{Colour, Piece, PieceType}, search::draw_score, threadlocal::ThreadData, util::MAX_DEPTH
 };
 
 /// The value of checkmate.
@@ -62,7 +57,8 @@ impl Board {
 
     pub fn evaluate_nnue(&self, t: &ThreadData) -> i32 {
         // get the raw network output
-        let v = t.nnue.evaluate(self.side);
+        let output_bucket = network::output_bucket(self);
+        let v = t.nnue.evaluate(self.side, output_bucket);
 
         // scale down the value estimate when there's not much
         // material left - this will incentivize keeping material

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -24,7 +24,7 @@ use crate::{
     },
     cuckoo,
     errors::{FenParseError, MoveParseError},
-    nnue, perft,
+    nnue::{self, network}, perft,
     piece::Colour,
     search::{parameters::Config, LMTable},
     searchinfo::SearchInfo,
@@ -580,7 +580,7 @@ pub fn main_loop(global_bench: bool) -> anyhow::Result<()> {
                 let eval = if pos.in_check() {
                     0
                 } else {
-                    thread_data.first_mut().with_context(|| "the thread headers are empty.")?.nnue.evaluate(pos.turn())
+                    thread_data.first_mut().with_context(|| "the thread headers are empty.")?.nnue.evaluate(pos.turn(), network::output_bucket(&pos))
                 };
                 println!("{eval}");
                 Ok(())


### PR DESCRIPTION
```
Elo   | 19.76 +- 6.80 (95%)
SPRT  | N=25000 Threads=1 Hash=16MB
LLR   | 3.06 (-2.94, 2.94) [0.00, 3.00]
Games | N: 4348 W: 1365 L: 1118 D: 1865
Penta | [87, 437, 919, 604, 127]
https://chess.swehosting.se/test/7374/
```
```
Elo   | 23.89 +- 6.91 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 2826 W: 781 L: 587 D: 1458
Penta | [14, 257, 686, 433, 23]
https://chess.swehosting.se/test/7376/
```