### PR TITLE
Correct static evaluation with TT value in qsearch.

### DIFF
--- a/IDEAS.txt
+++ b/IDEAS.txt
@@ -4,7 +4,6 @@ MAJOR:
 -- Crazyhouse
 
 MINOR:
--- datagen, data reanalysis, maybe other things
 - validate this FEN properly: "r3qrk1/pppb1pbp/3p1np1/3P2B1/2PpP3/2N2PP1/PP1Q3P/R3KB1R w kq - 0 4"
 - make optimism work
 - extra features in the unused pawn backranks for NNUE
@@ -13,14 +12,10 @@ MINOR:
   - bishop pair
   - passed pawns by file?
 - better errors for Fathom.
-- add filtering for counts
 - probcut tinkering (SF in-check trick)
 - futility tinkering
 - use history for more things
 - iir tinkering (ttmove, non-PV nodes, other fiddling)
-- tt correction 
-  - https://discord.com/channels/759496923324874762/866539700986970114/1258321981640671293
-  - http://chess.grantnet.us/test/37494/
 - eval corrhist 
   - https://github.com/connormcmonigle/seer-nnue/pull/185/files
   - google "low-rank"
@@ -32,6 +27,3 @@ ANNUEP:
 - quantisation
 - training run length
 - optimiser
-- weight decay
-- size
-- bucket count (i/o)

--- a/src/board/evaluation.rs
+++ b/src/board/evaluation.rs
@@ -1,7 +1,13 @@
 // The granularity of evaluation in this engine is in centipawns.
 
 use crate::{
-    board::Board, chessmove::Move, nnue::network, piece::{Colour, Piece, PieceType}, search::draw_score, threadlocal::ThreadData, util::MAX_DEPTH
+    board::Board,
+    chessmove::Move,
+    nnue::network,
+    piece::{Colour, Piece, PieceType},
+    search::draw_score,
+    threadlocal::ThreadData,
+    util::MAX_DEPTH,
 };
 
 /// The value of checkmate.

--- a/src/datagen/dataformat.rs
+++ b/src/datagen/dataformat.rs
@@ -132,10 +132,7 @@ impl Game {
     }
 
     /// Internally counts how many positions would pass the filter in this game.
-    pub fn filter_pass_count(
-        &self,
-        filter: impl Fn(Move, i32, &Board) -> bool,
-    ) -> u64 {
+    pub fn filter_pass_count(&self, filter: impl Fn(Move, i32, &Board) -> bool) -> u64 {
         let mut cnt = 0;
         let (mut board, _, _, _) = self.initial_position.unpack();
         for (mv, eval) in &self.moves {

--- a/src/nnue/network.rs
+++ b/src/nnue/network.rs
@@ -28,16 +28,8 @@ const SCALE: i32 = 400;
 /// The size of one-half of the hidden layer of the network.
 pub const LAYER_1_SIZE: usize = 1536;
 /// The structure of the king-buckets.
-const HALF_BUCKET_MAP: [usize; 32] = [
-    0, 1, 2, 3,
-    4, 4, 5, 5,
-    6, 6, 6, 6,
-    7, 7, 7, 7,
-    8, 8, 8, 8,
-    8, 8, 8, 8,
-    8, 8, 8, 8,
-    8, 8, 8, 8,
-];
+const HALF_BUCKET_MAP: [usize; 32] =
+    [0, 1, 2, 3, 4, 4, 5, 5, 6, 6, 6, 6, 7, 7, 7, 7, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8];
 /// The number of buckets in the feature transformer.
 pub const BUCKETS: usize = max!(HALF_BUCKET_MAP) + 1;
 /// The mapping from square to bucket.

--- a/src/search.rs
+++ b/src/search.rs
@@ -495,7 +495,18 @@ impl Board {
                 // if the TT eval is not VALUE_NONE, use it.
                 raw_eval = v;
             }
-            stand_pat = t.correct_evaluation(self, raw_eval);
+            let adj_eval = t.correct_evaluation(self, raw_eval);
+
+            // try correcting via search score from TT:
+            let (tt_flag, tt_value) = tt_hit.as_ref().map_or((Bound::None, VALUE_NONE), |tte| (tte.bound, tte.value));
+            if tt_flag == Bound::Exact
+                || tt_flag == Bound::Upper && tt_value < adj_eval
+                || tt_flag == Bound::Lower && tt_value > adj_eval
+            {
+                stand_pat = tt_value;
+            } else {
+                stand_pat = adj_eval;
+            }
         } else {
             // otherwise, use the static evaluation.
             raw_eval = self.evaluate(t, info.nodes.get_local());

--- a/src/search.rs
+++ b/src/search.rs
@@ -497,7 +497,8 @@ impl Board {
             }
             let adj_eval = t.correct_evaluation(self, raw_eval);
 
-            // try correcting via search score from TT:
+            // try correcting via search score from TT.
+            // notably, this doesn't work for main search for ~reasons.
             let (tt_flag, tt_value) = tt_hit.as_ref().map_or((Bound::None, VALUE_NONE), |tte| (tte.bound, tte.value));
             if tt_flag == Bound::Exact
                 || tt_flag == Bound::Upper && tt_value < adj_eval
@@ -510,10 +511,9 @@ impl Board {
         } else {
             // otherwise, use the static evaluation.
             raw_eval = self.evaluate(t, info.nodes.get_local());
-            if tt_hit.is_none() {
-                // store the eval into the TT if we won't overwrite anything
-                t.tt.store(key, height, None, VALUE_NONE, raw_eval, Bound::None, ZERO_PLY, t.ss[height].ttpv);
-            }
+            // store the eval into the TT. We know that we won't overwrite anything,
+            // because this branch is one where there wasn't a TT-hit.
+            t.tt.store(key, height, None, VALUE_NONE, raw_eval, Bound::None, ZERO_PLY, t.ss[height].ttpv);
             stand_pat = t.correct_evaluation(self, raw_eval);
         };
 

--- a/src/transpositiontable.rs
+++ b/src/transpositiontable.rs
@@ -84,7 +84,7 @@ impl TTEntry {
     fn to_ne_bytes(self) -> [u8; 10] {
         let mut memory = TTEntryReadTarget { bytes: 0 };
         memory.entry = self;
-        // SAFETY: TTEntry can be safely reinterpreted as bytes, and the 
+        // SAFETY: TTEntry can be safely reinterpreted as bytes, and the
         // whole u128 is initialised.
         let bytes = unsafe { memory.bytes };
         bytes.to_ne_bytes()[0..10].try_into().unwrap()
@@ -144,16 +144,14 @@ impl TTClusterMemory {
             _ => panic!("Index out of bounds!"),
         };
         // SAFETY: All bitpatterns of TTEntry are valid.
-        unsafe {
-            TTEntryReadTarget { bytes }.entry
-        }
+        unsafe { TTEntryReadTarget { bytes }.entry }
     }
 
     pub fn store(&self, idx: usize, entry: TTEntry) {
         #![allow(clippy::cast_possible_truncation)]
         let mut memory = TTEntryReadTarget { bytes: 0 };
         memory.entry = entry;
-        // SAFETY: TTEntry can be safely reinterpreted as bytes, and the 
+        // SAFETY: TTEntry can be safely reinterpreted as bytes, and the
         // whole u128 is initialised.
         let bytes = unsafe { memory.bytes };
         match idx {

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -24,7 +24,8 @@ use crate::{
     },
     cuckoo,
     errors::{FenParseError, MoveParseError},
-    nnue::{self, network}, perft,
+    nnue::{self, network},
+    perft,
     piece::Colour,
     search::{parameters::Config, LMTable},
     searchinfo::SearchInfo,
@@ -580,7 +581,11 @@ pub fn main_loop(global_bench: bool) -> anyhow::Result<()> {
                 let eval = if pos.in_check() {
                     0
                 } else {
-                    thread_data.first_mut().with_context(|| "the thread headers are empty.")?.nnue.evaluate(pos.turn(), network::output_bucket(&pos))
+                    thread_data
+                        .first_mut()
+                        .with_context(|| "the thread headers are empty.")?
+                        .nnue
+                        .evaluate(pos.turn(), network::output_bucket(&pos))
                 };
                 println!("{eval}");
                 Ok(())


### PR DESCRIPTION
```
Elo   | 1.91 +- 1.50 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 3.00]
Games | N: 55014 W: 12975 L: 12673 D: 29366
Penta | [226, 6296, 14166, 6588, 231]
https://chess.swehosting.se/test/7521/
```