### PR TITLE
IIR when ttentry is too shallow.

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -861,12 +861,12 @@ impl Board {
         let tt_capture = matches!(tt_move, Some(mv) if self.is_capture(mv));
 
         // TT-reduction (IIR).
-        if NT::PV && tt_hit.is_none() {
+        if NT::PV && tt_hit.map_or(true, |tte| tte.depth + 4 <= depth) {
             depth -= i32::from(depth >= info.conf.tt_reduction_depth);
         }
 
         // cutnode-based TT reduction.
-        if cut_node && excluded.is_none() && tt_move.is_none() {
+        if cut_node && excluded.is_none() && (tt_move.is_none() || tt_hit.map_or(true, |tte| tte.depth + 4 <= depth)) {
             depth -= i32::from(depth >= info.conf.tt_reduction_depth * 2);
         }
 


### PR DESCRIPTION
```
Elo   | 2.16 +- 1.67 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 3.00]
Games | N: 45108 W: 10281 L: 10001 D: 24826
Penta | [191, 5188, 11510, 5480, 185]
https://chess.swehosting.se/test/7622/
```