### PR TITLE
Only SEE-prune moves that land on threatened squares.

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -166,6 +166,10 @@ impl Board {
         self.ply
     }
 
+    pub const fn threats(&self) -> &Threats {
+        &self.threats
+    }
+
     pub fn king_sq(&self, side: Colour) -> Square {
         debug_assert!(side == Colour::White || side == Colour::Black);
         debug_assert_eq!(self.pieces.king::<White>().count(), 1);

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,12 +28,12 @@ mod searchinfo;
 mod squareset;
 mod stack;
 mod tablebases;
+mod term;
 mod threadlocal;
 mod timemgmt;
 mod transpositiontable;
 mod uci;
 mod util;
-mod term;
 
 use cli::Subcommands::{Analyse, Bench, CountPositions, Datagen, Perft, Splat, Spsa, VisNNUE};
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -861,12 +861,12 @@ impl Board {
         let tt_capture = matches!(tt_move, Some(mv) if self.is_capture(mv));
 
         // TT-reduction (IIR).
-        if NT::PV && tt_hit.is_none() {
+        if NT::PV && tt_hit.map_or(true, |tte| tte.depth + 4 <= depth) {
             depth -= i32::from(depth >= info.conf.tt_reduction_depth);
         }
 
         // cutnode-based TT reduction.
-        if cut_node && excluded.is_none() && tt_move.is_none() {
+        if cut_node && excluded.is_none() && (tt_move.is_none() || tt_hit.map_or(true, |tte| tte.depth + 4 <= depth)) {
             depth -= i32::from(depth >= info.conf.tt_reduction_depth * 2);
         }
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -998,6 +998,7 @@ impl Board {
                 && best_score > -MINIMUM_TB_WIN_SCORE
                 && depth <= info.conf.see_depth
                 && move_picker.stage > Stage::YieldGoodCaptures
+                && self.threats().all.contains_square(m.to())
                 && !self.static_exchange_eval(m, see_table[usize::from(is_quiet)])
             {
                 continue;

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -16,11 +16,25 @@ use std::{
 use anyhow::{anyhow, bail, Context};
 
 use crate::{
-    bench::BENCH_POSITIONS, board::{
+    bench::BENCH_POSITIONS,
+    board::{
         evaluation::{is_game_theoretic_score, is_mate_score, MATE_SCORE, TB_WIN_SCORE},
         movegen::MoveList,
         Board,
-    }, cuckoo, errors::{FenParseError, MoveParseError}, nnue::{self, network}, perft, piece::Colour, search::{parameters::Config, LMTable}, searchinfo::SearchInfo, tablebases, term, threadlocal::ThreadData, timemgmt::SearchLimit, transpositiontable::TT, util::{MAX_DEPTH, MEGABYTE}, NAME, VERSION
+    },
+    cuckoo,
+    errors::{FenParseError, MoveParseError},
+    nnue::{self, network},
+    perft,
+    piece::Colour,
+    search::{parameters::Config, LMTable},
+    searchinfo::SearchInfo,
+    tablebases, term,
+    threadlocal::ThreadData,
+    timemgmt::SearchLimit,
+    transpositiontable::TT,
+    util::{MAX_DEPTH, MEGABYTE},
+    NAME, VERSION,
 };
 
 const UCI_DEFAULT_HASH_MEGABYTES: usize = 16;


### PR DESCRIPTION
```
Elo   | 2.50 +- 1.86 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 3.00]
Games | N: 35798 W: 8158 L: 7900 D: 19740
Penta | [138, 4095, 9204, 4295, 167]
https://chess.swehosting.se/test/7628/
```