### PR TITLE
Significantly improve SIMD code quality.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -726,7 +726,7 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "viridithas"
-version = "14.0.1"
+version = "15.0.0"
 dependencies = [
  "anyhow",
  "arrayvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "viridithas"
-version = "14.0.1"
+version = "15.0.0"
 edition = "2021"
 description = "A superhuman chess engine."
 license = "MIT"


### PR DESCRIPTION
```
Elo   | -0.41 +- 1.08 (95%)
SPRT  | 1.0+0.01s Threads=1 Hash=16MB
LLR   | 3.03 (-2.94, 2.94) [-3.00, 0.00]
Games | N: 147436 W: 38562 L: 38736 D: 70138
Penta | [2600, 17054, 34595, 16858, 2611]
https://chess.swehosting.se/test/7917/
```