### PR TITLE
Use FT_SHIFT of 9 instead of 10

### DIFF
--- a/src/nnue/network/layers.rs
+++ b/src/nnue/network/layers.rs
@@ -125,7 +125,7 @@ mod x86simd {
     };
     use std::mem::MaybeUninit;
 
-    const FT_SHIFT: u32 = 10;
+    const FT_SHIFT: u32 = 9;
 
     #[derive(Debug, Clone, Copy)]
     #[repr(C, align(16))]


### PR DESCRIPTION
Merging for correctness reasons. Failed yellow.

```
Elo   | 0.16 +- 1.37 (95%)
SPRT  | N=25000 Threads=1 Hash=16MB
LLR   | -2.96 (-2.94, 2.94) [0.00, 3.00]
Games | N: 95870 W: 25832 L: 25788 D: 44250
Penta | [1748, 11605, 21217, 11585, 1780]
https://chess.swehosting.se/test/8144/
```