### PR TITLE
Make inference robust across architectures.

### DIFF
--- a/src/nnue/network.rs
+++ b/src/nnue/network.rs
@@ -86,6 +86,7 @@ const QB: i16 = 64;
 // have to do some path manipulation to get relative paths to work
 pub static COMPRESSED_NNUE: &[u8] = include_bytes!("../../viridithas.nnue.zst");
 
+/// Struct representing the floating-point parameter file emmitted by bullet.
 #[rustfmt::skip]
 #[repr(C)]
 struct UnquantisedNetwork {
@@ -100,6 +101,22 @@ struct UnquantisedNetwork {
     l3_biases:    [f32; OUTPUT_BUCKETS],
 }
 
+/// A quantised network file, for compressed embedding.
+#[rustfmt::skip]
+#[repr(C)]
+struct QuantisedNetwork {
+    ft_weights:   [i16; INPUT * L1_SIZE * BUCKETS],
+    ft_biases:    [i16; L1_SIZE],
+    l1_weights: [[[ i8; L2_SIZE]; OUTPUT_BUCKETS]; L1_SIZE],
+    l1_biases:   [[f32; L2_SIZE]; OUTPUT_BUCKETS],
+    l2_weights: [[[f32; L3_SIZE]; OUTPUT_BUCKETS]; L2_SIZE],
+    l2_biases:   [[f32; L3_SIZE]; OUTPUT_BUCKETS],
+    l3_weights:  [[f32; OUTPUT_BUCKETS]; L3_SIZE],
+    l3_biases:    [f32; OUTPUT_BUCKETS],
+}
+
+/// The parameters of viri's neural network, quantised and permuted
+/// for efficient SIMD inference.
 #[rustfmt::skip]
 #[repr(C)]
 pub struct NNUEParams {
@@ -126,46 +143,106 @@ const REPERMUTE_INDICES: [usize; L1_SIZE / 2] = {
 // const REPERMUTE_INDICES: [usize; L1_SIZE / 2] = [840, 838, 168, 364, 27, 147, 350, 469, 825, 343, 279, 759, 480, 78, 284, 483, 153, 80, 685, 872, 623, 436, 844, 1020, 824, 478, 694, 774, 686, 987, 337, 87, 495, 597, 487, 524, 120, 88, 360, 456, 702, 766, 744, 789, 1, 239, 803, 417, 333, 608, 368, 204, 301, 426, 385, 963, 843, 262, 526, 970, 883, 109, 401, 915, 36, 708, 948, 375, 118, 528, 905, 16, 717, 444, 243, 218, 180, 197, 43, 1001, 636, 199, 299, 796, 395, 21, 442, 511, 681, 158, 679, 598, 895, 520, 585, 1018, 509, 25, 131, 400, 277, 125, 182, 484, 688, 91, 479, 128, 216, 170, 581, 918, 268, 431, 863, 746, 238, 938, 105, 228, 293, 34, 414, 376, 576, 157, 741, 852, 492, 797, 622, 54, 297, 129, 728, 595, 537, 571, 854, 256, 315, 943, 831, 543, 639, 610, 745, 920, 485, 633, 267, 501, 737, 917, 514, 410, 990, 669, 453, 331, 196, 880, 813, 47, 723, 641, 248, 278, 121, 529, 516, 566, 448, 866, 348, 184, 772, 306, 402, 758, 981, 302, 835, 452, 15, 629, 229, 127, 496, 504, 270, 468, 86, 853, 934, 491, 734, 553, 942, 290, 369, 670, 664, 202, 213, 22, 579, 482, 236, 193, 477, 253, 380, 510, 906, 856, 49, 650, 443, 409, 931, 682, 321, 457, 503, 951, 1008, 276, 313, 163, 921, 995, 668, 827, 455, 308, 40, 877, 94, 933, 396, 894, 422, 223, 660, 538, 865, 704, 411, 142, 188, 465, 955, 830, 433, 140, 51, 397, 563, 66, 527, 839, 116, 782, 698, 439, 980, 882, 617, 750, 548, 275, 793, 381, 1016, 490, 474, 881, 99, 257, 135, 365, 837, 265, 644, 817, 513, 535, 8, 359, 982, 507, 338, 713, 10, 189, 435, 727, 370, 440, 146, 190, 62, 176, 523, 152, 155, 144, 540, 240, 795, 602, 65, 926, 74, 319, 773, 940, 45, 967, 873, 280, 994, 33, 407, 493, 604, 263, 783, 584, 663, 710, 525, 977, 35, 20, 464, 192, 826, 48, 1003, 821, 899, 577, 221, 73, 106, 373, 71, 209, 935, 649, 269, 859, 232, 536, 292, 769, 434, 72, 324, 778, 570, 361, 371, 619, 247, 757, 771, 342, 412, 60, 421, 711, 946, 736, 960, 953, 845, 654, 897, 547, 868, 884, 291, 901, 386, 219, 612, 645, 986, 947, 472, 964, 64, 388, 791, 675, 420, 601, 954, 600, 200, 707, 134, 310, 808, 258, 1015, 150, 89, 790, 181, 984, 779, 183, 855, 377, 505, 389, 683, 716, 862, 458, 731, 763, 286, 266, 676, 374, 497, 167, 929, 672, 642, 599, 285, 578, 560, 353, 210, 517, 283, 327, 287, 893, 356, 902, 973, 334, 903, 220, 760, 691, 542, 288, 703, 810, 767, 50, 557, 848, 857, 591, 822, 462, 701, 620, 515, 61, 384, 936, 624, 486, 635, 768, 889, 841, 860, 237, 349, 1017, 809, 44, 816, 419, 637, 178, 244, 326, 447, 110, 177, 316, 264, 989, 101, 508, 222, 621, 460, 561, 476, 945, 721, 30, 58, 646, 574, 205, 83, 273, 325, 345, 787, 961, 607, 531, 38, 37, 31, 587, 339, 415, 53, 613, 466, 569, 697, 939, 274, 871, 956, 42, 594, 32, 394, 628, 282, 770, 850, 1011, 425, 117, 993, 56, 14, 661, 296, 449, 226, 2, 648, 133, 7, 186, 798, 5, 161, 534, 784, 1012, 700, 39, 678, 530, 558, 786, 590, 46, 634, 846, 818, 781, 807, 556, 705, 937, 154, 544, 445, 861, 801, 693, 108, 502, 379, 59, 550, 405, 564, 347, 765, 609, 988, 966, 156, 847, 991, 596, 743, 169, 68, 1002, 870, 90, 565, 195, 294, 473, 217, 235, 305, 4, 304, 114, 317, 1000, 864, 699, 588, 241, 811, 834, 115, 191, 362, 552, 910, 932, 272, 726, 307, 67, 792, 533, 488, 13, 950, 254, 923, 311, 975, 430, 999, 885, 573, 748, 733, 165, 589, 665, 692, 398, 126, 927, 521, 996, 390, 626, 112, 81, 271, 76, 833, 175, 974, 11, 355, 555, 896, 351, 888, 618, 876, 832, 467, 408, 225, 605, 1009, 892, 77, 687, 667, 187, 0, 689, 559, 79, 215, 95, 814, 69, 742, 997, 489, 1019, 998, 102, 233, 211, 340, 17, 706, 928, 869, 652, 546, 715, 298, 113, 98, 84, 806, 393, 958, 3, 122, 52, 751, 250, 673, 625, 729, 214, 320, 968, 829, 657, 57, 104, 674, 851, 777, 886, 512, 70, 423, 799, 722, 451, 735, 1023, 461, 925, 231, 965, 738, 842, 913, 446, 143, 432, 363, 309, 914, 725, 185, 658, 93, 1022, 891, 261, 194, 922, 75, 138, 336, 404, 100, 399, 413, 494, 139, 224, 162, 712, 709, 611, 651, 874, 898, 383, 638, 323, 985, 575, 295, 976, 97, 437, 145, 630, 819, 500, 230, 992, 788, 655, 441, 580, 438, 959, 592, 983, 459, 136, 322, 366, 506, 92, 762, 85, 1004, 631, 541, 690, 780, 568, 603, 632, 662, 907, 732, 329, 828, 804, 406, 151, 206, 242, 812, 227, 159, 761, 656, 29, 18, 119, 344, 160, 260, 303, 251, 234, 593, 972, 312, 522, 1005, 137, 289, 328, 367, 900, 941, 532, 198, 815, 103, 203, 63, 26, 427, 392, 696, 201, 754, 372, 952, 858, 666, 640, 719, 281, 107, 149, 382, 416, 912, 130, 908, 23, 671, 919, 358, 179, 1021, 714, 470, 957, 429, 909, 55, 148, 518, 428, 615, 314, 387, 357, 28, 172, 208, 677, 582, 653, 539, 164, 1007, 24, 207, 606, 499, 684, 911, 823, 391, 740, 171, 904, 124, 756, 680, 794, 752, 519, 878, 971, 916, 424, 551, 300, 627, 747, 330, 481, 41, 249, 567, 805, 471, 836, 879, 875, 775, 764, 616, 659, 820, 586, 1014, 332, 132, 785, 96, 9, 141, 111, 867, 463, 890, 724, 583, 255, 695, 498, 245, 647, 730, 979, 403, 944, 166, 978, 352, 318, 718, 418, 6, 123, 450, 720, 572, 949, 1010, 174, 212, 962, 802, 454, 887, 749, 82, 354, 562, 346, 755, 614, 753, 545, 549, 969, 378, 475, 259, 12, 776, 800, 924, 930, 341, 246, 1013, 643, 335, 1006, 252, 849, 554, 739, 19, 173];
 
 impl UnquantisedNetwork {
-    #[allow(
-        clippy::cast_possible_truncation,
-        clippy::cast_precision_loss,
-        clippy::cognitive_complexity,
-        clippy::needless_range_loop,
-        clippy::too_many_lines,
-    )]
-    fn process(&self, use_simd: bool) -> Box<NNUEParams> {
+    /// Convert a parameter file generated by bullet into a quantised parameter set,
+    /// for embedding into viri as a zstd-compressed archive. We do one processing
+    /// step other than quantisation, namely merging the feature factoriser with the
+    /// main king buckets.
+    #[allow(clippy::cast_possible_truncation)]
+    fn quantise(&self) -> Box<QuantisedNetwork> {
         const QA_BOUND: f32 = 1.98 * QA as f32;
         const QB_BOUND: f32 = 1.98 * QB as f32;
 
-        let mut net = NNUEParams::zeroed();
-        // quantise the feature transformer weights
+        let mut net = QuantisedNetwork::zeroed();
+        // quantise the feature transformer weights, and merge the feature factoriser in.
         let mut buckets = self.ft_weights.chunks_exact(INPUT * L1_SIZE);
         let factoriser = buckets.next().unwrap();
-        for (src_bucket, tgt_bucket) in buckets.zip(net.feature_weights.chunks_exact_mut(INPUT * L1_SIZE)) {
+        for (src_bucket, tgt_bucket) in buckets.zip(net.ft_weights.chunks_exact_mut(INPUT * L1_SIZE)) {
             // for repermuting the weights.
-            let mut unsorted = vec![0i16; INPUT * L1_SIZE];
-            for ((src, fac_src), tgt) in src_bucket.iter().zip(factoriser.iter()).zip(unsorted.iter_mut()) {
+            for ((src, fac_src), tgt) in src_bucket.iter().zip(factoriser.iter()).zip(tgt_bucket.iter_mut()) {
+                // extra clamp in case bucket + factoriser goes out of the clipping bounds
                 let scaled = f32::clamp(*src + *fac_src, -1.98, 1.98) * f32::from(QA);
                 *tgt = scaled.round() as i16;
             }
-            repermute_ft_bucket(tgt_bucket, &unsorted);
         }
 
         // quantise the feature transformer biases
-        let mut unsorted = vec![0i16; L1_SIZE];
-        for (src, tgt) in self.ft_biases.iter().zip(unsorted.iter_mut()) {
+        for (src, tgt) in self.ft_biases.iter().zip(net.ft_biases.iter_mut()) {
             let scaled = *src * f32::from(QA);
             assert!(scaled.abs() <= QA_BOUND, "feature transformer bias {scaled} is too large (max = {QA_BOUND})");
             *tgt = scaled.round() as i16;
         }
-        repermute_ft_bias(&mut net.feature_bias, &unsorted);
+
+        // quantise (or not) later layers
+        for i in 0..L1_SIZE {
+            for bucket in 0..OUTPUT_BUCKETS {
+                for j in 0..L2_SIZE {
+                    let v = self.l1_weights[i][bucket][j] * f32::from(QB);
+                    assert!(v.abs() <= QB_BOUND, "L1 weight {v} is too large (max = {QB_BOUND})");
+                    let v = v.round() as i8;
+                    net.l1_weights[i][bucket][j] = v;
+                }
+            }
+        }
+
+        // transfer the L1 biases
+        net.l1_biases = self.l1_biases;
+        net.l2_weights = self.l2_weights;
+        net.l2_biases = self.l2_biases;
+        net.l3_weights = self.l3_weights;
+        net.l3_biases = self.l3_biases;
+
+        net
+    }
+
+    fn zeroed() -> Box<Self> {
+        // SAFETY: UnquantisedNetwork can be zeroed.
+        unsafe {
+            let layout = std::alloc::Layout::new::<Self>();
+            let ptr = std::alloc::alloc_zeroed(layout);
+            if ptr.is_null() {
+                std::alloc::handle_alloc_error(layout);
+            }
+            Box::from_raw(ptr.cast())
+        }
+    }
+
+    fn read(reader: &mut impl std::io::Read) -> anyhow::Result<Box<Self>> {
+        // SAFETY: NNUEParams can be zeroed.
+        unsafe {
+            let mut net = Self::zeroed();
+            let mem = std::slice::from_raw_parts_mut(
+                std::ptr::from_mut(net.as_mut()).cast::<u8>(),
+                std::mem::size_of::<Self>(),
+            );
+            reader.read_exact(mem)?;
+            Ok(net)
+        }
+    }
+}
+
+impl QuantisedNetwork {
+    /// Convert the network parameters into a format optimal for inference.
+    #[allow(clippy::cognitive_complexity, clippy::needless_range_loop)]
+    fn permute(&self, use_simd: bool) -> Box<NNUEParams> {
+        let mut net = NNUEParams::zeroed();
+        // permute the feature transformer weights
+        let src_buckets = self.ft_weights.chunks_exact(INPUT * L1_SIZE);
+        let tgt_buckets = net.feature_weights.chunks_exact_mut(INPUT * L1_SIZE);
+        for (src_bucket, tgt_bucket) in src_buckets.zip(tgt_buckets) {
+            repermute_ft_bucket(tgt_bucket, src_bucket);
+        }
+
+        // permute the feature transformer biases
+        repermute_ft_bias(&mut net.feature_bias, &self.ft_biases);
 
         // transpose FT weights and biases so that packus transposes it back to the intended order
         if use_simd {
             type PermChunk = [i16; 8];
             // reinterpret as data of size __m128i
-            let mut weights: Vec<&mut PermChunk> = net.feature_weights.chunks_exact_mut(8).map(|a| a.try_into().unwrap()).collect();
-            let mut biases: Vec<&mut PermChunk> = net.feature_bias.chunks_exact_mut(8).map(|a| a.try_into().unwrap()).collect();
+            let mut weights: Vec<&mut PermChunk> =
+                net.feature_weights.chunks_exact_mut(8).map(|a| a.try_into().unwrap()).collect();
+            let mut biases: Vec<&mut PermChunk> =
+                net.feature_bias.chunks_exact_mut(8).map(|a| a.try_into().unwrap()).collect();
             let num_chunks = std::mem::size_of::<PermChunk>() / std::mem::size_of::<i16>();
 
             #[cfg(target_feature = "avx512f")]
@@ -211,29 +288,23 @@ impl UnquantisedNetwork {
         }
 
         // transpose the L{1,2,3} weights and biases
-        let mut sorted = vec![[[0f32; L2_SIZE]; OUTPUT_BUCKETS]; L1_SIZE];
-        let l1_weights = &self.l1_weights;
-        repermute_l1_weights(&mut sorted, l1_weights);
+        let mut sorted = vec![[[0i8; L2_SIZE]; OUTPUT_BUCKETS]; L1_SIZE];
+        repermute_l1_weights(&mut sorted, &self.l1_weights);
         for bucket in 0..OUTPUT_BUCKETS {
             // quant the L1 weights
             if use_simd {
                 for i in 0..L1_SIZE / L1_CHUNK_PER_32 {
                     for j in 0..L2_SIZE {
                         for k in 0..L1_CHUNK_PER_32 {
-                            let v = sorted[i * L1_CHUNK_PER_32 + k][bucket][j] * f32::from(QB);
-                            assert!(v.abs() <= QB_BOUND, "L1 weight {v} is too large (max = {QB_BOUND})");
-                            let v = v.round() as i8;
-                            net.l1_weights[bucket][i * L1_CHUNK_PER_32 * L2_SIZE + j * L1_CHUNK_PER_32 + k] = v;
+                            net.l1_weights[bucket][i * L1_CHUNK_PER_32 * L2_SIZE + j * L1_CHUNK_PER_32 + k] =
+                                sorted[i * L1_CHUNK_PER_32 + k][bucket][j];
                         }
                     }
                 }
             } else {
                 for i in 0..L1_SIZE {
                     for j in 0..L2_SIZE {
-                        let v = sorted[i][bucket][j] * f32::from(QB);
-                        assert!(v.abs() <= QB_BOUND, "L1 weight {v} is too large (max = {QB_BOUND})");
-                        let v = v.round() as i8;
-                        net.l1_weights[bucket][j * L1_SIZE + i] = v;
+                        net.l1_weights[bucket][j * L1_SIZE + i] = sorted[i][bucket][j];
                     }
                 }
             }
@@ -276,7 +347,7 @@ impl UnquantisedNetwork {
     }
 
     fn zeroed() -> Box<Self> {
-        // SAFETY: UnquantisedNetwork can be zeroed.
+        // SAFETY: NNUEParams can be zeroed.
         unsafe {
             let layout = std::alloc::Layout::new::<Self>();
             let ptr = std::alloc::alloc_zeroed(layout);
@@ -287,18 +358,16 @@ impl UnquantisedNetwork {
         }
     }
 
-    fn read(reader: &mut impl std::io::Read) -> anyhow::Result<Box<Self>> {
-        // SAFETY: NNUEParams can be zeroed.
-        unsafe {
-            let mut net = Self::zeroed();
-            let mem = std::slice::from_raw_parts_mut(std::ptr::from_mut(net.as_mut()).cast::<u8>(), std::mem::size_of::<Self>());
-            reader.read_exact(mem)?;
-            Ok(net)
-        }
+    fn write(&self, writer: &mut impl std::io::Write) -> anyhow::Result<()> {
+        let ptr = std::ptr::from_ref::<Self>(self).cast::<u8>();
+        let len = std::mem::size_of::<Self>();
+        // SAFETY: We're writing a slice of bytes, and we know that the slice is valid.
+        writer.write_all(unsafe { std::slice::from_raw_parts(ptr, len) })?;
+        Ok(())
     }
 }
 
-fn repermute_l1_weights(sorted: &mut [[[f32; 16]; 8]], l1_weights: &[[[f32; 16]; 8]; 2048]) {
+fn repermute_l1_weights(sorted: &mut [[[i8; 16]; 8]], l1_weights: &[[[i8; 16]; 8]; 2048]) {
     for (tgt_index, src_index) in REPERMUTE_INDICES.iter().copied().enumerate() {
         sorted[tgt_index] = l1_weights[src_index];
     }
@@ -348,10 +417,10 @@ impl NNUEParams {
         // reinterpret it as bytes and write into it. We don't need to worry
         // about padding bytes, because the boxed NNUEParams is zeroed.
         unsafe {
-            let mut net = UnquantisedNetwork::zeroed();
+            let mut net = QuantisedNetwork::zeroed();
             let mut mem = std::slice::from_raw_parts_mut(
                 std::ptr::from_mut(net.as_mut()).cast::<u8>(),
-                std::mem::size_of::<UnquantisedNetwork>(),
+                std::mem::size_of::<QuantisedNetwork>(),
             );
             let expected_bytes = mem.len() as u64;
             let mut decoder = ZstdDecoder::new(COMPRESSED_NNUE)
@@ -360,7 +429,7 @@ impl NNUEParams {
                 std::io::copy(&mut decoder, &mut mem).with_context(|| "Failed to decompress NNUE weights.")?;
             anyhow::ensure!(bytes_written == expected_bytes, "encountered issue while decompressing NNUE weights, expected {expected_bytes} bytes, but got {bytes_written}");
             let use_simd = cfg!(target_feature = "ssse3");
-            let net = net.process(use_simd);
+            let net = net.permute(use_simd);
             Ok(net)
         }
     }
@@ -375,14 +444,6 @@ impl NNUEParams {
             }
             Box::from_raw(ptr.cast())
         }
-    }
-
-    fn write(&self, writer: &mut impl std::io::Write) -> anyhow::Result<()> {
-        let ptr = std::ptr::from_ref::<Self>(self).cast::<u8>();
-        let len = std::mem::size_of::<Self>();
-        // SAFETY: We're writing a slice of bytes, and we know that the slice is valid.
-        writer.write_all(unsafe { std::slice::from_raw_parts(ptr, len) })?;
-        Ok(())
     }
 
     pub fn select_feature_weights(&self, bucket: usize) -> &Align64<[i16; INPUT * L1_SIZE]> {
@@ -410,7 +471,7 @@ pub fn quantise(input: &std::path::Path, output: &std::path::Path) -> anyhow::Re
     let mut reader = BufReader::new(File::open(input)?);
     let mut writer = File::create(output)?;
     let unquantised_net = UnquantisedNetwork::read(&mut reader)?;
-    let net = unquantised_net.process(true);
+    let net = unquantised_net.quantise();
     net.write(&mut writer)?;
     Ok(())
 }

--- a/src/nnue/network.rs
+++ b/src/nnue/network.rs
@@ -315,17 +315,9 @@ impl QuantisedNetwork {
             }
 
             // transpose the L2 weights
-            if use_simd {
-                for i in 0..L2_SIZE {
-                    for j in 0..L3_SIZE {
-                        net.l2_weights[bucket][i * L3_SIZE + j] = self.l2_weights[i][bucket][j];
-                    }
-                }
-            } else {
-                for i in 0..L2_SIZE {
-                    for j in 0..L3_SIZE {
-                        net.l2_weights[bucket][j * L2_SIZE + i] = self.l2_weights[i][bucket][j];
-                    }
+            for i in 0..L2_SIZE {
+                for j in 0..L3_SIZE {
+                    net.l2_weights[bucket][i * L3_SIZE + j] = self.l2_weights[i][bucket][j];
                 }
             }
 
@@ -930,7 +922,11 @@ impl NNUEState {
 pub fn inference_benchmark(state: &NNUEState, nnue_params: &NNUEParams) {
     let start = std::time::Instant::now();
     for _ in 0..1_000_000 {
-        std::hint::black_box(state.evaluate(nnue_params, Colour::White, 0));
+        std::hint::black_box(std::hint::black_box(state).evaluate(
+            std::hint::black_box(nnue_params),
+            std::hint::black_box(Colour::White),
+            std::hint::black_box(0),
+        ));
     }
     let elapsed = start.elapsed();
     let nanos = elapsed.as_nanos();

--- a/src/nnue/network.rs
+++ b/src/nnue/network.rs
@@ -122,7 +122,7 @@ struct QuantisedNetwork {
 pub struct NNUEParams {
     pub feature_weights: Align64<[i16; INPUT * L1_SIZE * BUCKETS]>,
     pub feature_bias:    Align64<[i16; L1_SIZE]>,
-    pub l1_weights:     [Align64<[i8; L1_SIZE * L2_SIZE]>; OUTPUT_BUCKETS],
+    pub l1_weights:     [Align64<[ i8; L1_SIZE * L2_SIZE]>; OUTPUT_BUCKETS],
     pub l1_bias:        [Align64<[f32; L2_SIZE]>; OUTPUT_BUCKETS],
     pub l2_weights:     [Align64<[f32; L2_SIZE * L3_SIZE]>; OUTPUT_BUCKETS],
     pub l2_bias:        [Align64<[f32; L3_SIZE]>; OUTPUT_BUCKETS],

--- a/src/nnue/network/layers.rs
+++ b/src/nnue/network/layers.rs
@@ -394,7 +394,7 @@ mod x86simd {
         bias: f32,
         output: &mut f32,
     ) {
-        const NUM_SUMS: usize = AVX512CHUNK / (size_of::<VecF32>() / size_of::<f32>());
+        const NUM_SUMS: usize = AVX512CHUNK / (std::mem::size_of::<VecF32>() / std::mem::size_of::<f32>());
         // SAFETY: Breaking it down by unsafe operations:
         // 1. get_unchecked[_mut]: We only ever index at most (L3_SIZE / F32_CHUNK_SIZE - 1) * F32_CHUNK_SIZE
         // into the `weights` and `inputs` arrays. This is in bounds, as `weights` has length L3_SIZE and

--- a/src/nnue/network/layers.rs
+++ b/src/nnue/network/layers.rs
@@ -87,7 +87,7 @@ mod generic {
                 // and `weights` is `L2_SIZE * L3_SIZE` long. As such, the
                 // indices that we construct are valid.
                 unsafe {
-                    *sums.get_unchecked_mut(j) += *inputs.get_unchecked(i) * *weights.get_unchecked(j * L2_SIZE + i);
+                    *sums.get_unchecked_mut(j) += *inputs.get_unchecked(i) * *weights.get_unchecked(i * L3_SIZE + j);
                 }
             }
         }
@@ -356,14 +356,7 @@ mod x86simd {
         // has length L2_SIZE.
         // 2. SIMD instructions: All of our loads and stores are aligned.
         unsafe {
-            let mut sums = [0.0; L3_SIZE];
-
-            for i in 0..L3_SIZE / F32_CHUNK_SIZE {
-                simd::store_f32(
-                    sums.get_unchecked_mut(i * F32_CHUNK_SIZE),
-                    simd::load_f32(biases.get_unchecked(i * F32_CHUNK_SIZE)),
-                );
-            }
+            let mut sums = biases.clone();
 
             for i in 0..L2_SIZE {
                 let input_vec = simd::splat_f32(*inputs.get_unchecked(i));

--- a/src/nnue/network/layers.rs
+++ b/src/nnue/network/layers.rs
@@ -401,23 +401,21 @@ mod x86simd {
         // `inputs` has length L3_SIZE.
         // 2. SIMD instructions: All of our loads and stores are aligned.
         unsafe {
-            let mut sums = Align64([0.0; AVX512CHUNK]);
+            let mut sum = simd::zero_f32();
 
             // Affine transform for L3
             for i in 0..L3_SIZE / F32_CHUNK_SIZE {
                 let weight_vec = simd::load_f32(weights.get_unchecked(i * F32_CHUNK_SIZE));
                 let input_vec = simd::load_f32(inputs.get_unchecked(i * F32_CHUNK_SIZE));
-                simd::store_f32(
-                    sums.get_unchecked_mut(i % NUM_SUMS * F32_CHUNK_SIZE),
+                sum = 
                     simd::mul_add_f32(
                         input_vec,
                         weight_vec,
-                        simd::load_f32(sums.get_unchecked(i % NUM_SUMS * F32_CHUNK_SIZE)),
-                    ),
-                );
+                        sum,
+                    );
             }
 
-            *output = simd::reduce_add_f32s(&sums) + bias;
+            *output = simd::sum_f32(sum) + bias;
         }
     }
 }

--- a/src/nnue/simd.rs
+++ b/src/nnue/simd.rs
@@ -55,6 +55,7 @@ macro_rules! wrap_simd_register {
 mod avx512 {
     #![allow(non_camel_case_types)]
     use std::arch::x86_64::*;
+    use crate::nnue::network::Align64;
 
     wrap_simd_register!(__m512i, i8, VecI8);
     wrap_simd_register!(__m512i, i16, VecI16);
@@ -240,8 +241,8 @@ mod avx512 {
         return _mm512_reduce_add_ps(vec.inner());
     }
     #[inline]
-    pub unsafe fn reduce_add_f32s(vec: [VecF32; 1]) -> f32 {
-        return _mm512_reduce_add_ps(vec[0].inner());
+    pub unsafe fn reduce_add_f32s(vec: &Align64<[f32; 1 * F32_CHUNK_SIZE]>) -> f32 {
+        return _mm512_reduce_add_ps(load_f32(vec.get_unchecked(0 * F32_CHUNK_SIZE)).inner());
     }
 
     pub const U8_CHUNK_SIZE: usize = std::mem::size_of::<VecI8>() / std::mem::size_of::<u8>();
@@ -255,6 +256,7 @@ mod avx512 {
 mod avx2 {
     #![allow(non_camel_case_types)]
     use std::arch::x86_64::*;
+    use crate::nnue::network::Align64;
 
     wrap_simd_register!(__m256i, i8, VecI8);
     wrap_simd_register!(__m256i, i16, VecI16);
@@ -444,8 +446,8 @@ mod avx2 {
         return _mm_cvtss_f32(sum_32);
     }
     #[inline]
-    pub unsafe fn reduce_add_f32s(vec: [VecF32; 2]) -> f32 {
-        let vec = _mm256_add_ps(vec[0].inner(), vec[1].inner());
+    pub unsafe fn reduce_add_f32s(vec: &Align64<[f32; 2 * F32_CHUNK_SIZE]>) -> f32 {
+        let vec = _mm256_add_ps(load_f32(vec.get_unchecked(0 * F32_CHUNK_SIZE)).inner(), load_f32(vec.get_unchecked(1 * F32_CHUNK_SIZE)).inner());
 
         let upper_128 = _mm256_extractf128_ps(vec, 1);
         let lower_128 = _mm256_castps256_ps128(vec);
@@ -471,6 +473,7 @@ mod avx2 {
 mod ssse3 {
     #![allow(non_camel_case_types)]
     use std::arch::x86_64::*;
+    use crate::nnue::network::Align64;
 
     wrap_simd_register!(__m128i, i8, VecI8);
     wrap_simd_register!(__m128i, i16, VecI16);
@@ -654,9 +657,9 @@ mod ssse3 {
         return _mm_cvtss_f32(sum_32);
     }
     #[inline]
-    pub unsafe fn reduce_add_f32s(vec: [VecF32; 4]) -> f32 {
-        let vec_a = _mm_add_ps(vec[0].inner(), vec[2].inner());
-        let vec_b = _mm_add_ps(vec[1].inner(), vec[3].inner());
+    pub unsafe fn reduce_add_f32s(vec: &Align64<[f32; 4 * F32_CHUNK_SIZE]>) -> f32 {
+        let vec_a = _mm_add_ps(load_f32(vec.get_unchecked(0 * F32_CHUNK_SIZE)).inner(), load_f32(vec.get_unchecked(2 * F32_CHUNK_SIZE)).inner());
+        let vec_b = _mm_add_ps(load_f32(vec.get_unchecked(1 * F32_CHUNK_SIZE)).inner(), load_f32(vec.get_unchecked(3 * F32_CHUNK_SIZE)).inner());
         let vec = _mm_add_ps(vec_a, vec_b);
         let upper_64 = _mm_movehl_ps(vec, vec);
         let sum_64 = _mm_add_ps(vec, upper_64);


### PR DESCRIPTION
```
Elo   | 2.97 +- 4.07 (95%)
SPRT  | 1.0+0.01s Threads=1 Hash=16MB
LLR   | 2.99 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 9460 W: 2513 L: 2432 D: 4515
Penta | [133, 1013, 2367, 1074, 143]
https://chess.swehosting.se/test/8198/
```