### PR TITLE
Llinear history.

### DIFF
--- a/src/historytable.rs
+++ b/src/historytable.rs
@@ -6,13 +6,8 @@ use crate::{
 
 const AGEING_DIVISOR: i16 = 2;
 
-const fn history_bonus(depth: Depth) -> i32 {
-    let depth = depth.round();
-    if depth > 13 {
-        32
-    } else {
-        16 * depth * depth + 128 * max!(depth - 1, 0)
-    }
+fn history_bonus(depth: Depth) -> i32 {
+    i32::min(200 * depth.round(), 1600)
 }
 
 pub const MAX_HISTORY: i16 = i16::MAX / 2;


### PR DESCRIPTION
```
Elo   | 12.12 +- 4.98 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 3.00]
Games | N: 6050 W: 1616 L: 1405 D: 3029
Penta | [51, 648, 1441, 809, 76]
https://chess.swehosting.se/test/8450/
```