### PR TITLE
2-back `improving` with guard.

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -787,7 +787,15 @@ impl Board {
         // but we should be less aggressive with alpha-reductions (eval is too low).
         // some engines gain by using improving to increase LMR, but this shouldn't work imo, given that LMR is
         // neutral with regards to the evaluation.
-        let improving = !in_check && height >= 2 && static_eval >= t.ss[height - 2].eval;
+        let improving = if in_check {
+            false
+        } else if height >= 2 && t.ss[height - 2].eval != VALUE_NONE {
+            static_eval > t.ss[height - 2].eval
+        } else if height >= 4 && t.ss[height - 4].eval != VALUE_NONE {
+            static_eval > t.ss[height - 4].eval
+        } else {
+            true
+        };
 
         t.ss[height].dextensions = if NT::ROOT { 0 } else { t.ss[height - 1].dextensions };
 


### PR DESCRIPTION
STC:
```
Elo   | 1.67 +- 1.33 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.03 (-2.94, 2.94) [0.00, 3.00]
Games | N: 77616 W: 18650 L: 18276 D: 40690
Penta | [504, 9261, 18963, 9517, 563]
```
https://chess.swehosting.se/test/8556/

LTC:
```
Elo   | 2.07 +- 1.60 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 3.00]
Games | N: 45174 W: 10187 L: 9918 D: 25069
Penta | [78, 5149, 11889, 5368, 103]
```
https://chess.swehosting.se/test/8558/