### PR TITLE
Use history to modify SEE pruning margin.

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -1025,7 +1025,7 @@ impl Board {
                 && depth <= info.conf.see_depth
                 && move_picker.stage > Stage::YieldGoodCaptures
                 && self.threats().all.contains_square(m.to())
-                && !self.static_exchange_eval(m, see_table[usize::from(is_quiet)] + stat_score / 32)
+                && !self.static_exchange_eval(m, see_table[usize::from(is_quiet)] - stat_score / 32)
             {
                 continue;
             }

--- a/src/search.rs
+++ b/src/search.rs
@@ -986,7 +986,7 @@ impl Board {
                 stat_score += t.get_continuation_history_score(self, m, 1);
                 // stat_score += t.get_continuation_history_score(self, m, 3);
             } else {
-                // stat_score += t.get_tactical_history_score(self, m);
+                stat_score += t.get_tactical_history_score(self, m);
             }
 
             // lmp & fp.
@@ -1025,7 +1025,7 @@ impl Board {
                 && depth <= info.conf.see_depth
                 && move_picker.stage > Stage::YieldGoodCaptures
                 && self.threats().all.contains_square(m.to())
-                && !self.static_exchange_eval(m, see_table[usize::from(is_quiet)])
+                && !self.static_exchange_eval(m, see_table[usize::from(is_quiet)] + stat_score / 32)
             {
                 continue;
             }


### PR DESCRIPTION
```
Elo   | 9.90 +- 4.44 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 7338 W: 1851 L: 1642 D: 3845
Penta | [56, 801, 1765, 972, 75]
```
https://chess.swehosting.se/test/8661/