### PR TITLE
Remove material corrhist.

### DIFF
--- a/src/board/history.rs
+++ b/src/board/history.rs
@@ -232,7 +232,6 @@ impl ThreadData<'_> {
         update(self.nonpawn_corrhist[Black].get_mut(us, pos.non_pawn_key(Black)), new_weight, scaled_diff);
         update(self.minor_corrhist.get_mut(us, pos.minor_key()), new_weight, scaled_diff);
         update(self.major_corrhist.get_mut(us, pos.major_key()), new_weight, scaled_diff);
-        update(self.material_corrhist.get_mut(us, pos.material_key()), new_weight, scaled_diff);
     }
 
     /// Adjust a raw evaluation using statistics from the correction history.
@@ -243,8 +242,7 @@ impl ThreadData<'_> {
         let black = self.nonpawn_corrhist[Colour::Black].get(pos.turn(), pos.non_pawn_key(Colour::Black));
         let minor = self.minor_corrhist.get(pos.turn(), pos.minor_key());
         let major = self.major_corrhist.get(pos.turn(), pos.major_key());
-        let material = self.material_corrhist.get(pos.turn(), pos.material_key());
-        let adjustment = pawn + material + major + minor + white + black;
+        let adjustment = pawn + major + minor + white + black;
         raw_eval + adjustment as i32 / CORRECTION_HISTORY_GRAIN
     }
 }

--- a/src/threadlocal.rs
+++ b/src/threadlocal.rs
@@ -31,7 +31,6 @@ pub struct ThreadData<'a> {
     pub nonpawn_corrhist: [Box<CorrectionHistoryTable>; 2],
     pub major_corrhist: Box<CorrectionHistoryTable>,
     pub minor_corrhist: Box<CorrectionHistoryTable>,
-    pub material_corrhist: Box<CorrectionHistoryTable>,
 
     pub thread_id: usize,
 
@@ -65,7 +64,6 @@ impl<'a> ThreadData<'a> {
             nonpawn_corrhist: [CorrectionHistoryTable::boxed(), CorrectionHistoryTable::boxed()],
             major_corrhist: CorrectionHistoryTable::boxed(),
             minor_corrhist: CorrectionHistoryTable::boxed(),
-            material_corrhist: CorrectionHistoryTable::boxed(),
             thread_id,
             pvs: Self::EMPTY_PV_TABLE,
             completed: 0,
@@ -100,7 +98,6 @@ impl<'a> ThreadData<'a> {
         self.nonpawn_corrhist[Colour::Black].clear();
         self.major_corrhist.clear();
         self.minor_corrhist.clear();
-        self.material_corrhist.clear();
         self.killer_move_table.fill([None; 2]);
         self.counter_move_table.clear();
         self.depth = 0;

--- a/src/util.rs
+++ b/src/util.rs
@@ -393,8 +393,6 @@ pub struct Undo {
     pub minor_key: u64,
     /// The Zobrist hash of the major pieces on the board.
     pub major_key: u64,
-    /// The Zobrist hash of the counts of pieces on the board.
-    pub material_key: u64,
 }
 
 impl Default for Undo {
@@ -412,7 +410,6 @@ impl Default for Undo {
             non_pawn_key: [0; 2],
             minor_key: 0,
             major_key: 0,
-            material_key: 0,
         }
     }
 }


### PR DESCRIPTION
```
Elo   | 6.03 +- 3.28 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.01 (-2.94, 2.94) [0.00, 3.00]
Games | N: 12554 W: 3078 L: 2860 D: 6616
Penta | [78, 1409, 3090, 1617, 83]
```
https://chess.swehosting.se/test/8849/
```
Elo   | 3.33 +- 2.24 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 22964 W: 5215 L: 4995 D: 12754
Penta | [43, 2582, 6011, 2804, 42]
```
https://chess.swehosting.se/test/8850/