### PR TITLE
Guard QS SEE pruning a bit more.

### DIFF
--- a/src/datagen.rs
+++ b/src/datagen.rs
@@ -946,6 +946,7 @@ struct DataSetStats {
 }
 
 /// Scans a variable-length game format file and prints statistics about it.
+#[allow(clippy::too_many_lines)]
 pub fn dataset_stats(dataset_path: &Path) -> anyhow::Result<()> {
     let mut move_buffer = Vec::new();
     let mut stats = DataSetStats::default();

--- a/src/nnue/network.rs
+++ b/src/nnue/network.rs
@@ -289,7 +289,7 @@ impl UnquantisedNetwork {
 
 impl QuantisedNetwork {
     /// Convert the network parameters into a format optimal for inference.
-    #[allow(clippy::cognitive_complexity, clippy::needless_range_loop)]
+    #[allow(clippy::cognitive_complexity, clippy::needless_range_loop, clippy::too_many_lines)]
     fn permute(&self, use_simd: bool) -> Box<NNUEParams> {
         let mut net = NNUEParams::zeroed();
         // permute the feature transformer weights

--- a/src/search.rs
+++ b/src/search.rs
@@ -640,7 +640,13 @@ impl Board {
         let futility = stand_pat + 150;
 
         while let Some(MoveListEntry { mov: m, .. }) = move_picker.next(self, t) {
-            if !in_check && futility <= alpha && !self.static_exchange_eval(m, 1) {
+            let is_tactical = self.is_tactical(m);
+            if best_score > -MINIMUM_TB_WIN_SCORE
+                && is_tactical
+                && !in_check
+                && futility <= alpha
+                && !self.static_exchange_eval(m, 1)
+            {
                 if best_score < futility {
                     best_score = futility;
                 }

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -215,7 +215,7 @@ fn parse_go(text: &str, pos: &Board) -> anyhow::Result<SearchLimit> {
                 depth = Some(
                     part_parse("depth", parts.next())
                         .with_context(|| "Failed to parse depth part.")?,
-                )
+                );
             }
             "movestogo" => moves_to_go = Some(part_parse("movestogo", parts.next())?),
             "movetime" => movetime = Some(part_parse("movetime", parts.next())?),


### PR DESCRIPTION
```
Elo   | 3.14 +- 2.20 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 27036 W: 6462 L: 6218 D: 14356
Penta | [145, 3116, 6758, 3348, 151]
```
https://chess.swehosting.se/test/9181/