### PR TITLE
Remove `is_winning` from movesloop.

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -1138,11 +1138,7 @@ impl Board {
         let mut quiets_tried = ArrayVec::<_, MAX_POSITION_MOVES>::new();
         let mut tacticals_tried = ArrayVec::<_, MAX_POSITION_MOVES>::new();
 
-        while let Some(MoveListEntry {
-            mov: m,
-            score: movepick_score,
-        }) = move_picker.next(self, t)
-        {
+        while let Some(MoveListEntry { mov: m, .. }) = move_picker.next(self, t) {
             if excluded == Some(m) {
                 continue;
             }
@@ -1150,7 +1146,6 @@ impl Board {
             let lmr_reduction = info.lm_table.lm_reduction(depth, moves_made);
             let lmr_depth = std::cmp::max(depth - lmr_reduction, 0);
             let is_quiet = !self.is_tactical(m);
-            let is_winning_capture = movepick_score > WINNING_CAPTURE_SCORE;
 
             let mut stat_score = 0;
 
@@ -1285,7 +1280,7 @@ impl Board {
             } else if self.in_check() {
                 // self.in_check() determines if the opponent is in check,
                 // because we have already made the move.
-                extension = i32::from(is_quiet || is_winning_capture);
+                extension = i32::from(is_quiet);
             } else {
                 extension = 0;
             }
@@ -1318,9 +1313,6 @@ impl Board {
                         r += i32::from(!improving);
                         // reduce more if the move from the transposition table is tactical
                         r += i32::from(tt_capture);
-                    } else if is_winning_capture {
-                        // reduce winning captures less
-                        r -= 1;
                     }
                     r.clamp(1, depth - 1)
                 } else {


### PR DESCRIPTION
```
Elo   | 5.45 +- 3.03 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 12682 W: 2889 L: 2690 D: 7103
Penta | [17, 1424, 3266, 1611, 23]
```
https://chess.swehosting.se/test/9202/

```
Elo   | 5.09 +- 3.00 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 14946 W: 3573 L: 3354 D: 8019
Penta | [81, 1716, 3678, 1899, 99]
```
https://chess.swehosting.se/test/9201/