### PR TITLE
Simplify continuation history indexing.

### DIFF
--- a/src/chess/board/mod.rs
+++ b/src/chess/board/mod.rs
@@ -20,7 +20,7 @@ use crate::{
         chessmove::Move,
         piece::{Black, Col, Colour, Piece, PieceType, White},
         squareset::SquareSet,
-        types::{CastlingRights, CheckState, ContHistIndex, File, Rank, Square, Undo},
+        types::{CastlingRights, CheckState, File, Rank, Square, Undo},
         CHESS960,
     },
     cuckoo,
@@ -113,10 +113,6 @@ impl Board {
 
     pub const fn ep_sq(&self) -> Option<Square> {
         self.ep_sq
-    }
-
-    pub fn history(&self) -> &[Undo] {
-        &self.history
     }
 
     #[cfg(feature = "datagen")]
@@ -1134,10 +1130,6 @@ impl Board {
             ep_square: self.ep_sq,
             fifty_move_counter: self.fifty_move_counter,
             threats: self.threats,
-            cont_hist_index: Some(ContHistIndex {
-                piece,
-                square: m.history_to_square(),
-            }),
             piece_layout: self.pieces,
             piece_array: self.piece_array,
             key: self.key,

--- a/src/chess/piece.rs
+++ b/src/chess/piece.rs
@@ -71,9 +71,10 @@ impl Display for PieceType {
 }
 
 #[rustfmt::skip]
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Default)]
 #[repr(u8)]
 pub enum Piece {
+    #[default]
     WP, WN, WB, WR, WQ, WK,
     BP, BN, BB, BR, BQ, BK,
 }

--- a/src/chess/types.rs
+++ b/src/chess/types.rs
@@ -144,9 +144,10 @@ impl<T> IndexMut<Rank> for [T; 8] {
 }
 
 #[rustfmt::skip]
-#[derive(PartialEq, Eq, Clone, Copy, PartialOrd, Ord, Hash, Debug)]
+#[derive(PartialEq, Eq, Clone, Copy, PartialOrd, Ord, Hash, Debug, Default)]
 #[repr(u8)]
 pub enum Square {
+    #[default]
     A1, B1, C1, D1, E1, F1, G1, H1,
     A2, B2, C2, D2, E2, F2, G2, H2,
     A3, B3, C3, D3, E3, F3, G3, H3,
@@ -396,7 +397,7 @@ pub const BKCA: u8 = 0b0100;
 
 pub const BQCA: u8 = 0b1000;
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
 pub struct ContHistIndex {
     pub piece: Piece,
     pub square: Square,
@@ -408,7 +409,6 @@ pub struct Undo {
     pub ep_square: Option<Square>,
     pub fifty_move_counter: u8,
     pub threats: Threats,
-    pub cont_hist_index: Option<ContHistIndex>,
     pub piece_layout: PieceLayout,
     pub piece_array: [Option<Piece>; 64],
     /// The Zobrist hash of the board.
@@ -433,7 +433,6 @@ impl Default for Undo {
                 all: SquareSet::EMPTY,
                 checkers: SquareSet::EMPTY,
             },
-            cont_hist_index: None,
             piece_layout: PieceLayout::NULL,
             piece_array: [None; 64],
             key: 0,

--- a/src/search.rs
+++ b/src/search.rs
@@ -668,6 +668,11 @@ impl Board {
             t.tt.prefetch(self.key_after(m));
             t.ss[height].searching = Some(m);
             t.ss[height].searching_tactical = is_tactical;
+            let moved = self.piece_at(m.from()).unwrap();
+            t.ss[height].conthist_index = ContHistIndex {
+                piece: moved,
+                square: m.history_to_square(),
+            };
             if !self.make_move(m, t) {
                 continue;
             }
@@ -1011,6 +1016,11 @@ impl Board {
                     );
                 let nm_depth = depth - r;
                 t.ss[height].searching = None;
+                t.ss[height].searching_tactical = false;
+                t.ss[height].conthist_index = ContHistIndex {
+                    piece: Piece::new(self.turn(), PieceType::Pawn),
+                    square: Square::A1,
+                };
                 self.make_nullmove();
                 let mut null_score =
                     -self.alpha_beta::<OffPV>(l_pv, info, t, nm_depth, -beta, -beta + 1, !cut_node);
@@ -1112,6 +1122,11 @@ impl Board {
                 t.tt.prefetch(self.key_after(m));
                 t.ss[height].searching = Some(m);
                 t.ss[height].searching_tactical = true;
+                let moved = self.piece_at(m.from()).unwrap();
+                t.ss[height].conthist_index = ContHistIndex {
+                    piece: moved,
+                    square: m.history_to_square(),
+                };
                 if !self.make_move(m, t) {
                     // illegal move
                     continue;
@@ -1293,6 +1308,11 @@ impl Board {
                 // re-make the singular move.
                 t.ss[height].searching = Some(m);
                 t.ss[height].searching_tactical = !is_quiet;
+                let moved = self.piece_at(m.from()).unwrap();
+                t.ss[height].conthist_index = ContHistIndex {
+                    piece: moved,
+                    square: m.history_to_square(),
+                };
                 self.make_move(m, t);
 
                 if value < r_beta {

--- a/src/search.rs
+++ b/src/search.rs
@@ -21,7 +21,7 @@ use crate::{
         chessmove::Move,
         piece::{Colour, Piece, PieceType},
         squareset::SquareSet,
-        types::Square,
+        types::{ContHistIndex, Square},
         CHESS960,
     },
     evaluation::{
@@ -1237,6 +1237,11 @@ impl Board {
             t.tt.prefetch(self.key_after(m));
             t.ss[height].searching = Some(m);
             t.ss[height].searching_tactical = !is_quiet;
+            let moved = self.piece_at(m.from()).unwrap();
+            t.ss[height].conthist_index = ContHistIndex {
+                piece: moved,
+                square: m.history_to_square(),
+            };
             if !self.make_move(m, t) {
                 continue;
             }

--- a/src/stack.rs
+++ b/src/stack.rs
@@ -1,4 +1,4 @@
-use crate::chess::chessmove::Move;
+use crate::chess::{chessmove::Move, types::ContHistIndex};
 
 #[derive(Default, Clone)]
 #[allow(clippy::module_name_repetitions)]
@@ -10,4 +10,5 @@ pub struct StackEntry {
     pub searching_tactical: bool,
     pub dextensions: i32,
     pub ttpv: bool,
+    pub conthist_index: ContHistIndex,
 }


### PR DESCRIPTION
```
Elo   | 3.63 +- 4.22 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 7842 W: 1939 L: 1857 D: 4046
Penta | [51, 923, 1904, 979, 64]
```
https://chess.swehosting.se/test/9556/