### PR TITLE
Simplify to a single killer-move.

### DIFF
--- a/src/history.rs
+++ b/src/history.rs
@@ -240,11 +240,7 @@ impl ThreadData<'_> {
     pub fn insert_killer(&mut self, pos: &Board, m: Move) {
         debug_assert!(pos.height() < MAX_PLY);
         let idx = pos.height();
-        if self.killer_move_table[idx][0] == Some(m) {
-            return;
-        }
-        self.killer_move_table[idx][1] = self.killer_move_table[idx][0];
-        self.killer_move_table[idx][0] = Some(m);
+        self.killer_move_table[idx] = Some(m);
     }
 
     /// Add a move to the countermove table.

--- a/src/perft.rs
+++ b/src/perft.rs
@@ -80,7 +80,7 @@ pub fn movepicker_perft(
         return 1;
     }
 
-    let mut ml = MovePicker::new(None, [None, None], None, 0);
+    let mut ml = MovePicker::new(None, None, None, 0);
 
     let mut count = 0;
     while let Some(m) = ml.next(pos, t, info) {

--- a/src/threadlocal.rs
+++ b/src/threadlocal.rs
@@ -27,7 +27,7 @@ pub struct ThreadData<'a> {
     pub main_history: ThreatsHistoryTable,
     pub tactical_history: Box<CaptureHistoryTable>,
     pub continuation_history: Box<DoubleHistoryTable>,
-    pub killer_move_table: [[Option<Move>; 2]; MAX_PLY + 1],
+    pub killer_move_table: [Option<Move>; MAX_PLY + 1],
     pub counter_move_table: MoveTable,
     pub pawn_corrhist: Box<CorrectionHistoryTable>,
     pub nonpawn_corrhist: [Box<CorrectionHistoryTable>; 2],
@@ -64,7 +64,7 @@ impl<'a> ThreadData<'a> {
             main_history: ThreatsHistoryTable::new(),
             tactical_history: CaptureHistoryTable::boxed(),
             continuation_history: DoubleHistoryTable::boxed(),
-            killer_move_table: [[None; 2]; MAX_PLY + 1],
+            killer_move_table: [None; MAX_PLY + 1],
             counter_move_table: MoveTable::new(),
             pawn_corrhist: CorrectionHistoryTable::boxed(),
             nonpawn_corrhist: [
@@ -122,7 +122,7 @@ impl<'a> ThreadData<'a> {
         self.nonpawn_corrhist[Colour::Black].clear();
         self.major_corrhist.clear();
         self.minor_corrhist.clear();
-        self.killer_move_table.fill([None; 2]);
+        self.killer_move_table.fill(None);
         self.counter_move_table.clear();
         self.depth = 0;
         self.completed = 0;
@@ -133,7 +133,7 @@ impl<'a> ThreadData<'a> {
         self.main_history.age_entries();
         self.tactical_history.age_entries();
         self.continuation_history.age_entries();
-        self.killer_move_table.fill([None; 2]);
+        self.killer_move_table.fill(None);
         self.counter_move_table.clear();
         self.depth = 0;
         self.completed = 0;


### PR DESCRIPTION
```
Elo   | 0.90 +- 2.79 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.05 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 17742 W: 4339 L: 4293 D: 9110
Penta | [103, 2189, 4266, 2185, 128]
https://chess.swehosting.se/test/10153/
```