### PR TITLE
Reduce rounding error in granular LMR.

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -1952,12 +1952,12 @@ impl LMTable {
             clippy::cast_sign_loss
         )]
         let mut out = Self::NULL;
-        let (base, division) = (config.lmr_base / 100.0, config.lmr_division / 100.0);
+        let (base, division) = (config.lmr_base / 100.0 * 1024.0, config.lmr_division / 100.0 / 1024.0);
         cfor!(let mut depth = 1; depth < 64; depth += 1; {
             cfor!(let mut played = 1; played < 64; played += 1; {
                 let ld = f64::ln(depth as f64);
                 let lp = f64::ln(played as f64);
-                out.lm_reduction_table[depth][played] = (base + 1024.0 + ld * lp * 1024.0 / division) as i32;
+                out.lm_reduction_table[depth][played] = (base + ld * lp / division) as i32;
             });
         });
         cfor!(let mut depth = 1; depth < 12; depth += 1; {

--- a/src/search.rs
+++ b/src/search.rs
@@ -1957,7 +1957,7 @@ impl LMTable {
             cfor!(let mut played = 1; played < 64; played += 1; {
                 let ld = f64::ln(depth as f64);
                 let lp = f64::ln(played as f64);
-                out.lm_reduction_table[depth][played] = (base + ld * lp / division) as i32 * 1024;
+                out.lm_reduction_table[depth][played] = (base + 1024.0 + ld * lp * 1024.0 / division) as i32;
             });
         });
         cfor!(let mut depth = 1; depth < 12; depth += 1; {

--- a/src/search.rs
+++ b/src/search.rs
@@ -1249,7 +1249,7 @@ impl Board {
             }
 
             let lmr_reduction = info.lm_table.lm_reduction(depth, moves_made);
-            let lmr_depth = std::cmp::max(depth - lmr_reduction, 0);
+            let lmr_depth = std::cmp::max(depth - lmr_reduction / 1024, 0);
             let is_quiet = !self.is_tactical(m);
 
             let mut stat_score = 0;
@@ -1414,7 +1414,7 @@ impl Board {
             } else {
                 // calculation of LMR stuff
                 let r = if depth > 2 && moves_made > (1 + usize::from(NT::PV)) {
-                    let mut r = info.lm_table.lm_reduction(depth, moves_made) * 1024;
+                    let mut r = info.lm_table.lm_reduction(depth, moves_made);
                     if is_quiet {
                         // extend/reduce using the stat_score of the move
                         r -= stat_score * 1024 / info.conf.history_lmr_divisor;
@@ -1970,7 +1970,7 @@ impl LMTable {
     pub fn lm_reduction(&self, depth: i32, moves_made: usize) -> i32 {
         let depth: usize = depth.clamp(0, 63).try_into().unwrap_or_default();
         let played = moves_made.min(63);
-        self.lm_reduction_table[depth][played]
+        self.lm_reduction_table[depth][played] * 1024
     }
 
     pub fn lmp_movecount(&self, depth: i32, improving: bool) -> usize {

--- a/src/search.rs
+++ b/src/search.rs
@@ -1957,7 +1957,7 @@ impl LMTable {
             cfor!(let mut played = 1; played < 64; played += 1; {
                 let ld = f64::ln(depth as f64);
                 let lp = f64::ln(played as f64);
-                out.lm_reduction_table[depth][played] = (base + ld * lp / division) as i32;
+                out.lm_reduction_table[depth][played] = (base + ld * lp / division) as i32 * 1024;
             });
         });
         cfor!(let mut depth = 1; depth < 12; depth += 1; {
@@ -1970,7 +1970,7 @@ impl LMTable {
     pub fn lm_reduction(&self, depth: i32, moves_made: usize) -> i32 {
         let depth: usize = depth.clamp(0, 63).try_into().unwrap_or_default();
         let played = moves_made.min(63);
-        self.lm_reduction_table[depth][played] * 1024
+        self.lm_reduction_table[depth][played]
     }
 
     pub fn lmp_movecount(&self, depth: i32, improving: bool) -> usize {

--- a/src/search/parameters.rs
+++ b/src/search/parameters.rs
@@ -360,7 +360,7 @@ impl Config {
             INCREMENT_FRAC = [self.increment_frac, 1, 100, 10],
             NODE_TM_SUBTREE_MULTIPLIER = [self.node_tm_subtree_multiplier, 1, 1000, 15],
             FAIL_LOW_TM_BONUS = [self.fail_low_tm_bonus, 1, 1000, 30],
-            HISTORY_LMR_DIVISOR = [self.history_lmr_divisor, 1, 16383, 100],
+            HISTORY_LMR_DIVISOR = [self.history_lmr_divisor, 1, 65536, 512],
             QS_SEE_BOUND = [self.qs_see_bound, -500, 500, 50],
             MAIN_SEE_BOUND = [self.main_see_bound, -500, 500, 50],
             DO_DEEPER_BASE_MARGIN = [self.do_deeper_base_margin, 1, 200, 20],


### PR DESCRIPTION
```
Elo   | -0.46 +- 1.70 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.09 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 45720 W: 10873 L: 10934 D: 23913
Penta | [251, 5560, 11303, 5491, 255]
https://chess.swehosting.se/test/10236/
```