### PR TITLE
Expand usage of LMR conditions.

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -1415,16 +1415,16 @@ impl Board {
                 // calculation of LMR stuff
                 let r = if depth > 2 && moves_made > (1 + usize::from(NT::PV)) {
                     let mut r = info.lm_table.lm_reduction(depth, moves_made);
+                    // reduce more on non-PV nodes
+                    r += i32::from(!NT::PV) * info.conf.lmr_non_pv_mul;
+                    r -= i32::from(t.ss[height].ttpv) * info.conf.lmr_ttpv_mul;
+                    // reduce more on cut nodes
+                    r += i32::from(cut_node) * info.conf.lmr_cut_node_mul;
                     if is_quiet {
                         // extend/reduce using the stat_score of the move
                         r -= stat_score * 1024 / info.conf.history_lmr_divisor;
                         // reduce refutation moves less
                         r -= i32::from(killer_or_counter) * info.conf.lmr_refutation_mul;
-                        // reduce more on non-PV nodes
-                        r += i32::from(!NT::PV) * info.conf.lmr_non_pv_mul;
-                        r -= i32::from(t.ss[height].ttpv) * info.conf.lmr_ttpv_mul;
-                        // reduce more on cut nodes
-                        r += i32::from(cut_node) * info.conf.lmr_cut_node_mul;
                         // reduce more if not improving
                         r += i32::from(!improving) * info.conf.lmr_non_improving_mul;
                         // reduce more if the move from the transposition table is tactical

--- a/src/transpositiontable.rs
+++ b/src/transpositiontable.rs
@@ -477,7 +477,7 @@ impl TTView<'_> {
                 }
             }
         }
-        hit / 2 * CLUSTER_SIZE
+        hit / (2 * CLUSTER_SIZE)
     }
 }
 


### PR DESCRIPTION
```
Elo   | 1.69 +- 1.36 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 71562 W: 17166 L: 16818 D: 37578
Penta | [378, 8487, 17758, 8725, 433]
https://chess.swehosting.se/test/10237/
```