### PR TITLE
Increase NMP reduction when TT move is a capture.

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -1087,7 +1087,8 @@ impl Board {
                     + std::cmp::min(
                         (static_eval - beta) / info.conf.nmp_reduction_eval_divisor,
                         4,
-                    );
+                    )
+                    + i32::from(tt_capture);
                 let nm_depth = depth - r;
                 t.ss[height].searching = None;
                 t.ss[height].searching_tactical = false;


### PR DESCRIPTION
```
Elo   | 1.11 +- 0.80 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 202118 W: 47556 L: 46911 D: 107651
Penta | [1057, 23989, 50281, 24716, 1016]
https://chess.swehosting.se/test/10248/
```