### PR TITLE
Tidy movepicker.

### DIFF
--- a/src/movepicker.rs
+++ b/src/movepicker.rs
@@ -173,7 +173,7 @@ impl MovePicker {
         while let Some((best_num, m)) = self.movelist[self.index..]
             .iter_mut()
             .enumerate()
-            .reduce(|a, b| if a.1.score > b.1.score { a } else { b })
+            .reduce(|a, b| if a.1.score >= b.1.score { a } else { b })
         {
             debug_assert!(
                 m.score < WINNING_CAPTURE_SCORE / 2 || m.score >= MIN_WINNING_SEE_SCORE,


### PR DESCRIPTION
```
Elo   | -0.88 +- 1.45 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=16MB
LLR   | -0.22 (-2.94, 2.94) [-3.00, 0.00]
Games | N: 63612 W: 15687 L: 15848 D: 32077
Penta | [557, 7065, 16678, 6994, 512]
https://chess.swehosting.se/test/10306/
```