### PR TITLE
Extend whole node in some circumstances where prior reduction is large.

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -1037,8 +1037,12 @@ impl Board {
         let tt_move = tt_hit.and_then(|hit| hit.mov);
         let tt_capture = matches!(tt_move, Some(mv) if self.is_capture(mv));
 
-        // whole-node pruning techniques:
+        // whole-node techniques:
         if !NT::ROOT && !NT::PV && !in_check && excluded.is_none() {
+            if t.ss[height - 1].reduction >= 4096 && static_eval + t.ss[height - 1].eval < 0 {
+                depth += 1;
+            }
+
             if depth >= 2
                 && t.ss[height - 1].reduction >= 2048
                 && t.ss[height - 1].eval != VALUE_NONE


### PR DESCRIPTION
```
Elo   | 4.04 +- 2.59 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 3.00]
Games | N: 19946 W: 4893 L: 4661 D: 10392
Penta | [119, 2299, 4899, 2543, 113]
https://chess.swehosting.se/test/10523/
```