### PR TITLE
Simplify conditions for entering quiescence.

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -787,12 +787,9 @@ impl Board {
 
         let key = self.state.keys.zobrist;
 
-        let in_check = self.in_check();
-        if depth <= 0 && !in_check {
+        if depth <= 0 {
             return self.quiescence::<NT::Next>(pv, info, t, alpha, beta);
         }
-
-        depth = depth.max(0);
 
         pv.moves.clear();
 
@@ -811,6 +808,8 @@ impl Board {
         } else {
             info.seldepth.max(i32::try_from(height).unwrap())
         };
+
+        let in_check = self.in_check();
 
         if !NT::ROOT {
             // check draw


### PR DESCRIPTION
```
Elo   | 1.91 +- 2.36 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [-3.00, 0.00]
Games | N: 23414 W: 5612 L: 5483 D: 12319
Penta | [110, 2760, 5871, 2823, 143]
https://chess.swehosting.se/test/10525/
```