### PR TITLE
Increase RFP margin when correction is large.

### DIFF
--- a/src/chess/piece.rs
+++ b/src/chess/piece.rs
@@ -224,25 +224,12 @@ impl Piece {
         }
     }
 
-    pub const fn byte_char(self) -> u8 {
-        match self {
-            Self::WP => b'P',
-            Self::WN => b'N',
-            Self::WB => b'B',
-            Self::WR => b'R',
-            Self::WQ => b'Q',
-            Self::WK => b'K',
-            Self::BP => b'p',
-            Self::BN => b'n',
-            Self::BB => b'b',
-            Self::BR => b'r',
-            Self::BQ => b'q',
-            Self::BK => b'k',
-        }
+    pub fn byte_char(self) -> u8 {
+        b"PNBRQKpnbrqk"[self]
     }
 
     pub fn all() -> impl DoubleEndedIterator<Item = Self> {
-        // SAFETY: all values are within `0..6`.
+        // SAFETY: all values are within `0..12`.
         (0..12u8).map(|i| unsafe { std::mem::transmute(i) })
     }
 

--- a/src/history.rs
+++ b/src/history.rs
@@ -294,7 +294,7 @@ impl ThreadData<'_> {
 
     /// Adjust a raw evaluation using statistics from the correction history.
     #[allow(clippy::cast_possible_truncation)]
-    pub fn correct_evaluation(&self, conf: &Config, pos: &Board) -> i32 {
+    pub fn correction(&self, conf: &Config, pos: &Board) -> i32 {
         let keys = &pos.state.keys;
         let pawn = self.pawn_corrhist.get(pos.turn(), keys.pawn);
         let white =


### PR DESCRIPTION
```
Elo   | 1.87 +- 1.49 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 59598 W: 14428 L: 14107 D: 31063
Penta | [325, 7061, 14739, 7316, 358]
https://chess.swehosting.se/test/10583/
```