### PR TITLE
Taper late evaluations correctly across transpositions.

### DIFF
--- a/src/evaluation.rs
+++ b/src/evaluation.rs
@@ -85,11 +85,6 @@ impl Board {
         // material off if the position is worse for us.
         let v = v * self.material_scale(info) / 1024;
 
-        // scale down the value when the fifty-move counter is high.
-        // this goes some way toward making viri realise when he's not
-        // making progress in a position.
-        let v = v * (200 - i32::from(self.fifty_move_counter())) / 200;
-
         // clamp the value into the valid range.
         // this basically never comes up, but the network will
         // occasionally output OOB values in crazy positions with

--- a/src/search.rs
+++ b/src/search.rs
@@ -629,7 +629,7 @@ impl Board {
                 // if the TT eval is not VALUE_NONE, use it.
                 raw_eval = v;
             }
-            let adj_eval = raw_eval + t.correction(&info.conf, self);
+            let adj_eval = shuffle_scale(raw_eval, self.fifty_move_counter()) + t.correction(&info.conf, self);
 
             // try correcting via search score from TT.
             // notably, this doesn't work for main search for ~reasons.
@@ -661,7 +661,7 @@ impl Board {
                 t.ss[height].ttpv,
             );
 
-            stand_pat = raw_eval + t.correction(&info.conf, self);
+            stand_pat = shuffle_scale(raw_eval, self.fifty_move_counter()) + t.correction(&info.conf, self);
         }
 
         if stand_pat >= beta {
@@ -966,7 +966,7 @@ impl Board {
                 }
             }
             correction = t.correction(&info.conf, self);
-            static_eval = raw_eval + correction;
+            static_eval = shuffle_scale(raw_eval, self.fifty_move_counter()) + correction;
         } else {
             // otherwise, use the static evaluation.
             raw_eval = self.evaluate(t, info, info.nodes.get_local());
@@ -985,7 +985,7 @@ impl Board {
             );
 
             correction = t.correction(&info.conf, self);
-            static_eval = raw_eval + correction;
+            static_eval = shuffle_scale(raw_eval, self.fifty_move_counter()) + correction;
         }
 
         t.ss[height].eval = static_eval;
@@ -1819,6 +1819,10 @@ impl Board {
         // the side that is to move after loop exit is the loser.
         self.turn() != colour
     }
+}
+
+fn shuffle_scale(raw_eval: i32, ply: u8) -> i32 {
+    raw_eval * (200 - i32::from(ply)) / 200
 }
 
 pub fn select_best<'a>(

--- a/src/search.rs
+++ b/src/search.rs
@@ -592,8 +592,10 @@ impl Board {
             }
         }
 
+        let clock = self.fifty_move_counter();
+
         // probe the TT and see if we get a cutoff.
-        let fifty_move_rule_near = self.fifty_move_counter() >= 80;
+        let fifty_move_rule_near = clock >= 80;
         let tt_hit = if let Some(hit) = t.tt.probe(key, height) {
             if !NT::PV
                 && !in_check
@@ -629,7 +631,7 @@ impl Board {
                 // if the TT eval is not VALUE_NONE, use it.
                 raw_eval = v;
             }
-            let adj_eval = shuffle_scale(raw_eval, self.fifty_move_counter()) + t.correction(&info.conf, self);
+            let adj_eval = adj_shuffle(raw_eval, clock) + t.correction(&info.conf, self);
 
             // try correcting via search score from TT.
             // notably, this doesn't work for main search for ~reasons.
@@ -661,7 +663,7 @@ impl Board {
                 t.ss[height].ttpv,
             );
 
-            stand_pat = shuffle_scale(raw_eval, self.fifty_move_counter()) + t.correction(&info.conf, self);
+            stand_pat = adj_shuffle(raw_eval, clock) + t.correction(&info.conf, self);
         }
 
         if stand_pat >= beta {
@@ -843,8 +845,10 @@ impl Board {
             }
         }
 
+        let clock = self.fifty_move_counter();
+
         let excluded = t.ss[height].excluded;
-        let fifty_move_rule_near = self.fifty_move_counter() >= 80;
+        let fifty_move_rule_near = clock >= 80;
         let tt_hit = if excluded.is_none() {
             if let Some(hit) = t.tt.probe(key, height) {
                 if !NT::PV
@@ -966,7 +970,7 @@ impl Board {
                 }
             }
             correction = t.correction(&info.conf, self);
-            static_eval = shuffle_scale(raw_eval, self.fifty_move_counter()) + correction;
+            static_eval = adj_shuffle(raw_eval, clock) + correction;
         } else {
             // otherwise, use the static evaluation.
             raw_eval = self.evaluate(t, info, info.nodes.get_local());
@@ -985,7 +989,7 @@ impl Board {
             );
 
             correction = t.correction(&info.conf, self);
-            static_eval = shuffle_scale(raw_eval, self.fifty_move_counter()) + correction;
+            static_eval = adj_shuffle(raw_eval, clock) + correction;
         }
 
         t.ss[height].eval = static_eval;
@@ -1612,7 +1616,8 @@ impl Board {
 
     /// The margin for Reverse Futility Pruning.
     fn rfp_margin(info: &SearchInfo, depth: i32, improving: bool, correction: i32) -> i32 {
-        info.conf.rfp_margin * depth - i32::from(improving) * info.conf.rfp_improving_margin + correction.abs() / 2
+        info.conf.rfp_margin * depth - i32::from(improving) * info.conf.rfp_improving_margin
+            + correction.abs() / 2
     }
 
     /// Update the main and continuation history tables for a batch of moves.
@@ -1821,8 +1826,8 @@ impl Board {
     }
 }
 
-fn shuffle_scale(raw_eval: i32, ply: u8) -> i32 {
-    raw_eval * (200 - i32::from(ply)) / 200
+fn adj_shuffle(raw_eval: i32, clock: u8) -> i32 {
+    raw_eval * (200 - i32::from(clock)) / 200
 }
 
 pub fn select_best<'a>(


### PR DESCRIPTION
```
Elo   | 2.08 +- 1.64 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 50366 W: 12214 L: 11913 D: 26239
Penta | [292, 5980, 12352, 6253, 306]
https://chess.swehosting.se/test/10625/
```