### PR TITLE
fix forward promotion evasion generation in movepicker

### DIFF
--- a/src/chess/board/movegen.rs
+++ b/src/chess/board/movegen.rs
@@ -680,6 +680,12 @@ impl Board {
             return;
         }
 
+        let valid_forward_promo_target_squares = if self.in_check() {
+            RAY_BETWEEN[our_king_sq][self.state.threats.checkers.first()]
+        } else {
+            SquareSet::FULL
+        };
+
         let valid_target_squares = if self.in_check() {
             self.state.threats.checkers
         } else {
@@ -687,7 +693,7 @@ impl Board {
         };
 
         // promotions
-        self.generate_forward_promos::<C, Mode>(move_list, valid_target_squares);
+        self.generate_forward_promos::<C, Mode>(move_list, valid_forward_promo_target_squares);
 
         // pawn captures and capture promos
         self.generate_pawn_caps::<C, Mode>(move_list, valid_target_squares);

--- a/src/perft.rs
+++ b/src/perft.rs
@@ -295,6 +295,37 @@ mod tests {
     }
 
     #[test]
+    fn perft_movepicker_forward_promo_evasion() {
+        use super::*;
+        const TEST_FEN: &str = "r7/P2r4/7R/8/5p2/5K2/3p2P1/R5k1 b - - 0 1";
+
+        std::env::set_var("RUST_BACKTRACE", "1");
+        let mut pos = Board::new();
+        pos.set_from_fen(TEST_FEN).unwrap();
+        let mut tt = TT::new();
+        tt.resize(MEGABYTE * 16, 1);
+        let nnue_params = NNUEParams::decompress_and_alloc().unwrap();
+        let mut t = ThreadData::new(0, &pos, tt.view(), nnue_params);
+        let stopped = AtomicBool::new(false);
+        let nodes = AtomicU64::new(0);
+        let info = SearchInfo::new(&stopped, &nodes);
+        assert_eq!(
+            movepicker_perft(&mut pos, &mut t, &info, 1),
+            4,
+            "got {}",
+            {
+                pos.legal_moves()
+                    .into_iter()
+                    .map(|m| m.display(CHESS960.load(Ordering::Relaxed)).to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            }
+        );
+        assert_eq!(movepicker_perft(&mut pos, &mut t, &info, 2), 62);
+        assert_eq!(movepicker_perft(&mut pos, &mut t, &info, 3), 1474);
+    }
+
+    #[test]
     fn perft_krk() {
         use super::*;
 


### PR DESCRIPTION
Viri lost [this game](https://www.chess.com/computer-chess-championship#event=ccc24-bullet-qualifier-3&game=252) against SP at CCC, because it did not generate promotions on d1 on move 79. The problem is that `generate_captures_for` was only generating captures of the checking piece if in check - forward promos, though considered noisy and generated in that function, would always be masked off. This issue didn't appear in perft, because the issue is exclusive to staged movegen.