### PR TITLE
Expand range of LMR.

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -1432,14 +1432,14 @@ impl Board {
                     // reduce less if the move gives check
                     r -= i32::from(self.in_check()) * info.conf.lmr_check_mul;
                     t.ss[height].reduction = r;
-                    (r / 1024).clamp(1, depth - 1)
+                    r / 1024
                 } else {
                     t.ss[height].reduction = 1024;
                     1
                 };
                 // perform a zero-window search
                 let mut new_depth = depth + extension;
-                let reduced_depth = new_depth - r;
+                let reduced_depth = (new_depth - r).clamp(0, new_depth);
                 score = -self.alpha_beta::<OffPV>(
                     l_pv,
                     info,


### PR DESCRIPTION
```
Elo   | 1.93 +- 1.54 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.94 (-2.94, 2.94) [0.00, 3.00]
Games | N: 56332 W: 13705 L: 13392 D: 29235
Penta | [315, 6641, 13969, 6898, 343]
https://chess.swehosting.se/test/10681/
```