### PR TITLE
Update history of inbound edge on fail-high.

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -1581,6 +1581,23 @@ impl Board {
             );
         }
 
+        if !NT::ROOT && flag == Bound::Upper {
+            // the current node has failed low. this means that the inbound edge to this node
+            // will fail high, so we can give a bonus to that edge.
+            let ss_prev = &t.ss[height - 1];
+            if let Some(mov) = ss_prev.searching {
+                if !ss_prev.searching_tactical {
+                    let from = mov.from();
+                    let to = mov.history_to_square();
+                    let moved = self.piece_at(to).expect("Cannot fail, move has been made.");
+                    debug_assert_eq!(moved.colour(), !self.turn());
+                    let threats = self.history().last().unwrap().threats.all;
+                    let bonus = main_history_bonus(&info.conf, depth);
+                    t.update_history_single(from, to, moved, threats, bonus);
+                }
+            }
+        }
+
         if excluded.is_none() {
             debug_assert!(
                 alpha != original_alpha || best_move.is_none(),


### PR DESCRIPTION
```
Elo   | 3.75 +- 2.47 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 3.00]
Games | N: 21760 W: 5405 L: 5170 D: 11185
Penta | [120, 2522, 5365, 2749, 124]
https://chess.swehosting.se/test/10686/
```
```
Elo   | 1.85 +- 1.46 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 53954 W: 12397 L: 12110 D: 29447
Penta | [79, 6245, 14065, 6486, 102]
https://chess.swehosting.se/test/10694/
```