### PR TITLE
More robust optimism implementation.

### DIFF
--- a/src/uci.rs
+++ b/src/uci.rs
@@ -39,7 +39,7 @@ use crate::{
         network::{self, NNUEParams},
     },
     perft,
-    search::{parameters::Config, LMTable},
+    search::{adj_shuffle, parameters::Config, LMTable},
     searchinfo::SearchInfo,
     tablebases, term,
     threadlocal::ThreadData,
@@ -691,13 +691,11 @@ pub fn main_loop() -> anyhow::Result<()> {
                 let eval = if pos.in_check() {
                     0
                 } else {
-                    pos.evaluate(
-                        thread_data
-                            .first_mut()
-                            .with_context(|| "the thread headers are empty.")?,
-                        &info,
-                        0,
-                    )
+                    let t = thread_data
+                        .first_mut()
+                        .with_context(|| "the thread headers are empty.")?;
+                    let eval = pos.evaluate(t, 0);
+                    adj_shuffle(&pos, t, &info, eval, pos.fifty_move_counter())
                 };
                 println!("{eval}");
                 Ok(())


### PR DESCRIPTION
```
Elo   | 3.14 +- 2.88 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [-3.00, 0.00]
Games | N: 16280 W: 4054 L: 3907 D: 8319
Penta | [91, 1928, 3953, 2079, 89]
https://chess.swehosting.se/test/10824/
```