### PR TITLE
Fix incorrect pin behaviour in SEE after null-move.

### DIFF
--- a/src/chess/board/mod.rs
+++ b/src/chess/board/mod.rs
@@ -1218,7 +1218,6 @@ impl Board {
         self.height += 1;
 
         self.state.threats = self.generate_threats(self.side);
-        self.state.pinned.swap(0, 1);
 
         #[cfg(debug_assertions)]
         self.check_validity().unwrap();

--- a/src/search.rs
+++ b/src/search.rs
@@ -1294,6 +1294,7 @@ pub fn alpha_beta<NT: NodeType>(
             && depth < 10
             && move_picker.stage > Stage::YieldGoodCaptures
             && board.state.threats.all.contains_square(m.to())
+            && t.ss[height - 1].searching.is_some()
             && !static_exchange_eval(
                 board,
                 info,


### PR DESCRIPTION
```
Elo   | 0.82 +- 1.83 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [-3.00, 0.00]
Games | N: 39036 W: 9517 L: 9425 D: 20094
Penta | [225, 4569, 9824, 4689, 211]
https://chess.swehosting.se/test/10857/
```