### PR TITLE
Treat pins properly in SEE.

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -15,7 +15,7 @@ use crate::{
     cfor,
     chess::{
         board::{
-            movegen::{self, MAX_POSITION_MOVES, RAY_INTERSECTING},
+            movegen::{self, MAX_POSITION_MOVES, RAY_FULL},
             Board,
         },
         chessmove::Move,
@@ -1782,8 +1782,8 @@ pub fn static_exchange_eval(board: &Board, info: &SearchInfo, m: Move, threshold
     let white_king = kings & bbs.colours[Colour::White];
     let black_king = kings & bbs.colours[Colour::Black];
 
-    let white_king_ray = RAY_INTERSECTING[to][white_king.first()];
-    let black_king_ray = RAY_INTERSECTING[to][black_king.first()];
+    let white_king_ray = RAY_FULL[to][white_king.first()];
+    let black_king_ray = RAY_FULL[to][black_king.first()];
 
     let allowed = !(white_pinned | black_pinned)
         | (white_pinned & white_king_ray)


### PR DESCRIPTION
```
Elo   | 0.82 +- 1.76 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [-3.00, 0.00]
Games | N: 38220 W: 9221 L: 9131 D: 19868
Penta | [177, 4096, 10488, 4158, 191]
https://chess.swehosting.se/test/10877/
```