### PR TITLE
Tweak prior-move history update.

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -1583,7 +1583,7 @@ pub fn alpha_beta<NT: NodeType>(
         );
     }
 
-    if !NT::ROOT && flag == Bound::Upper {
+    if !NT::ROOT && flag == Bound::Upper && (!quiets_tried.is_empty() || depth > 3) {
         // the current node has failed low. this means that the inbound edge to this node
         // will fail high, so we can give a bonus to that edge.
         let ss_prev = &t.ss[height - 1];


### PR DESCRIPTION
yeah it's a yellow. what are you going to do about it
```
Elo   | 0.46 +- 0.85 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | -2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 184100 W: 44399 L: 44157 D: 95544
Penta | [985, 22060, 45791, 22156, 1058]
https://chess.swehosting.se/test/10895/
```