### PR TITLE
Fix Stacked Borrows violations

### DIFF
--- a/src/nnue/accumulator.rs
+++ b/src/nnue/accumulator.rs
@@ -81,23 +81,29 @@ mod x86simd {
             for i in 0..L1_SIZE / UNROLL {
                 let unroll_offset = i * UNROLL;
                 for (r_idx, reg) in registers.iter_mut().enumerate() {
-                    let src = input.get_unchecked(unroll_offset + r_idx * I16_CHUNK_SIZE);
+                    let src = input.as_ptr().add(unroll_offset + r_idx * I16_CHUNK_SIZE);
                     *reg = simd::load_i16(src);
                 }
                 for &sub_block in &sub_blocks {
                     for (r_idx, reg) in registers.iter_mut().enumerate() {
-                        let src = sub_block.get_unchecked(unroll_offset + r_idx * I16_CHUNK_SIZE);
+                        let src = sub_block
+                            .as_ptr()
+                            .add(unroll_offset + r_idx * I16_CHUNK_SIZE);
                         *reg = simd::sub_i16(*reg, simd::load_i16(src));
                     }
                 }
                 for &add_block in &add_blocks {
                     for (r_idx, reg) in registers.iter_mut().enumerate() {
-                        let src = add_block.get_unchecked(unroll_offset + r_idx * I16_CHUNK_SIZE);
+                        let src = add_block
+                            .as_ptr()
+                            .add(unroll_offset + r_idx * I16_CHUNK_SIZE);
                         *reg = simd::add_i16(*reg, simd::load_i16(src));
                     }
                 }
                 for (r_idx, reg) in registers.iter().enumerate() {
-                    let dst = input.get_unchecked_mut(unroll_offset + r_idx * I16_CHUNK_SIZE);
+                    let dst = input
+                        .as_mut_ptr()
+                        .add(unroll_offset + r_idx * I16_CHUNK_SIZE);
                     simd::store_i16(dst, *reg);
                 }
             }
@@ -126,12 +132,12 @@ mod x86simd {
         for i in 0..L1_SIZE / I16_CHUNK_SIZE {
             // SAFETY: we never hold multiple mutable references, we never mutate immutable memory, etc.
             unsafe {
-                let x = simd::load_i16(input.get_unchecked(i * I16_CHUNK_SIZE));
-                let w_sub = simd::load_i16(s_block.get_unchecked(i * I16_CHUNK_SIZE));
-                let w_add = simd::load_i16(a_block.get_unchecked(i * I16_CHUNK_SIZE));
+                let x = simd::load_i16(input.as_ptr().add(i * I16_CHUNK_SIZE));
+                let w_sub = simd::load_i16(s_block.as_ptr().add(i * I16_CHUNK_SIZE));
+                let w_add = simd::load_i16(a_block.as_ptr().add(i * I16_CHUNK_SIZE));
                 let t = simd::sub_i16(x, w_sub);
                 let t = simd::add_i16(t, w_add);
-                simd::store_i16(output.get_unchecked_mut(i * I16_CHUNK_SIZE), t);
+                simd::store_i16(output.as_mut_ptr().add(i * I16_CHUNK_SIZE), t);
             }
         }
     }
@@ -162,14 +168,14 @@ mod x86simd {
         for i in 0..L1_SIZE / I16_CHUNK_SIZE {
             // SAFETY: we never hold multiple mutable references, we never mutate immutable memory, etc.
             unsafe {
-                let x = simd::load_i16(input.get_unchecked(i * I16_CHUNK_SIZE));
-                let w_sub1 = simd::load_i16(s_block1.get_unchecked(i * I16_CHUNK_SIZE));
-                let w_sub2 = simd::load_i16(s_block2.get_unchecked(i * I16_CHUNK_SIZE));
-                let w_add = simd::load_i16(a_block.get_unchecked(i * I16_CHUNK_SIZE));
+                let x = simd::load_i16(input.as_ptr().add(i * I16_CHUNK_SIZE));
+                let w_sub1 = simd::load_i16(s_block1.as_ptr().add(i * I16_CHUNK_SIZE));
+                let w_sub2 = simd::load_i16(s_block2.as_ptr().add(i * I16_CHUNK_SIZE));
+                let w_add = simd::load_i16(a_block.as_ptr().add(i * I16_CHUNK_SIZE));
                 let t = simd::sub_i16(x, w_sub1);
                 let t = simd::sub_i16(t, w_sub2);
                 let t = simd::add_i16(t, w_add);
-                simd::store_i16(output.get_unchecked_mut(i * I16_CHUNK_SIZE), t);
+                simd::store_i16(output.as_mut_ptr().add(i * I16_CHUNK_SIZE), t);
             }
         }
     }
@@ -204,16 +210,16 @@ mod x86simd {
         for i in 0..L1_SIZE / I16_CHUNK_SIZE {
             // SAFETY: we never hold multiple mutable references, we never mutate immutable memory, etc.
             unsafe {
-                let x = simd::load_i16(input.get_unchecked(i * I16_CHUNK_SIZE));
-                let w_sub1 = simd::load_i16(s_block1.get_unchecked(i * I16_CHUNK_SIZE));
-                let w_sub2 = simd::load_i16(s_block2.get_unchecked(i * I16_CHUNK_SIZE));
-                let w_add1 = simd::load_i16(a_block1.get_unchecked(i * I16_CHUNK_SIZE));
-                let w_add2 = simd::load_i16(a_block2.get_unchecked(i * I16_CHUNK_SIZE));
+                let x = simd::load_i16(input.as_ptr().add(i * I16_CHUNK_SIZE));
+                let w_sub1 = simd::load_i16(s_block1.as_ptr().add(i * I16_CHUNK_SIZE));
+                let w_sub2 = simd::load_i16(s_block2.as_ptr().add(i * I16_CHUNK_SIZE));
+                let w_add1 = simd::load_i16(a_block1.as_ptr().add(i * I16_CHUNK_SIZE));
+                let w_add2 = simd::load_i16(a_block2.as_ptr().add(i * I16_CHUNK_SIZE));
                 let t = simd::sub_i16(x, w_sub1);
                 let t = simd::sub_i16(t, w_sub2);
                 let t = simd::add_i16(t, w_add1);
                 let t = simd::add_i16(t, w_add2);
-                simd::store_i16(output.get_unchecked_mut(i * I16_CHUNK_SIZE), t);
+                simd::store_i16(output.as_mut_ptr().add(i * I16_CHUNK_SIZE), t);
             }
         }
     }

--- a/src/nnue/network/layers.rs
+++ b/src/nnue/network/layers.rs
@@ -172,7 +172,7 @@ mod x86simd {
             },
             simd::{self, VecI32, F32_CHUNK_SIZE, I16_CHUNK_SIZE, S, U8_CHUNK_SIZE},
         },
-        util::{from_mut, from_ref},
+        util::from_ref,
     };
     use std::{
         arch::x86_64::{
@@ -255,10 +255,10 @@ mod x86simd {
         const SHIFT: S = 16 - FT_SHIFT as S;
 
         // SAFETY: Breaking it down by unsafe operations:
-        // 1. get_unchecked[_mut]: We only ever index at most
+        // 1. get_unchecked[_mut] / .as[_mut]_ptr().add(): We only ever index at most
         // div_ceil(L1_PAIR_COUNT - 1, I16_CHUNK_SIZE * 2) + I16_CHUNK_SIZE + L1_PAIR_COUNT
         // into the `acc` array. This is in bounds, as `acc` has length L1_PAIR_COUNT * 2.
-        // Additionally, we only ever indexx at most div_ceil(L1_PAIR_COUNT - 1, I16_CHUNK_SIZE * 2) + L1_PAIR_COUNT
+        // Additionally, we only ever index at most div_ceil(L1_PAIR_COUNT - 1, I16_CHUNK_SIZE * 2) + L1_PAIR_COUNT
         // into the `ft_outputs` array. This is in bounds, as `ft_outputs` has length L1_PAIR_COUNT * 2.
         // 2. SIMD instructions: All of our loads and stores are aligned.
         // 3. Use of MaybeUninit: We always store into the entirety of `ft_outputs`, before
@@ -278,19 +278,21 @@ mod x86simd {
 
             let mut offset = 0;
             for acc in [us, them] {
+                let acc_ptr = acc.as_ptr();
+
                 for i in (0..L1_PAIR_COUNT).step_by(I16_CHUNK_SIZE * 2 * 2) {
                     // load the left-hand pair inputs
-                    let input0a = simd::load_i16(acc.get_unchecked(i + 0 * I16_CHUNK_SIZE));
-                    let input0b = simd::load_i16(acc.get_unchecked(i + 1 * I16_CHUNK_SIZE));
-                    let input0c = simd::load_i16(acc.get_unchecked(i + 2 * I16_CHUNK_SIZE));
-                    let input0d = simd::load_i16(acc.get_unchecked(i + 3 * I16_CHUNK_SIZE));
+                    let input0a = simd::load_i16(acc_ptr.add(i + 0 * I16_CHUNK_SIZE));
+                    let input0b = simd::load_i16(acc_ptr.add(i + 1 * I16_CHUNK_SIZE));
+                    let input0c = simd::load_i16(acc_ptr.add(i + 2 * I16_CHUNK_SIZE));
+                    let input0d = simd::load_i16(acc_ptr.add(i + 3 * I16_CHUNK_SIZE));
 
                     // load the right-hand pair inputs
                     let j = i + L1_PAIR_COUNT;
-                    let input1a = simd::load_i16(acc.get_unchecked(j + 0 * I16_CHUNK_SIZE));
-                    let input1b = simd::load_i16(acc.get_unchecked(j + 1 * I16_CHUNK_SIZE));
-                    let input1c = simd::load_i16(acc.get_unchecked(j + 2 * I16_CHUNK_SIZE));
-                    let input1d = simd::load_i16(acc.get_unchecked(j + 3 * I16_CHUNK_SIZE));
+                    let input1a = simd::load_i16(acc_ptr.add(j + 0 * I16_CHUNK_SIZE));
+                    let input1b = simd::load_i16(acc_ptr.add(j + 1 * I16_CHUNK_SIZE));
+                    let input1c = simd::load_i16(acc_ptr.add(j + 2 * I16_CHUNK_SIZE));
+                    let input1d = simd::load_i16(acc_ptr.add(j + 3 * I16_CHUNK_SIZE));
 
                     // crelu the left-hand inputs
                     let clipped0a = simd::min_i16(simd::max_i16(input0a, ft_zero), ft_one);
@@ -315,12 +317,12 @@ mod x86simd {
                     let product_two = simd::pack_i16_to_u8(productc, productd);
 
                     // store to the ft output buffer
+                    simd::store_u8(ft_outputs.as_mut_ptr().add(offset + i).cast(), product_one);
                     simd::store_u8(
-                        from_mut(ft_outputs.get_unchecked_mut(offset + i)).cast(),
-                        product_one,
-                    );
-                    simd::store_u8(
-                        from_mut(ft_outputs.get_unchecked_mut(offset + i + U8_CHUNK_SIZE)).cast(),
+                        ft_outputs
+                            .as_mut_ptr()
+                            .add(offset + i + U8_CHUNK_SIZE)
+                            .cast(),
                         product_two,
                     );
 
@@ -336,10 +338,10 @@ mod x86simd {
                     // store the non-zero indices into the nnz buffer
                     for j in 0..NNZ_OUTPUTS_PER_CHUNK {
                         let lookup = (nnz_mask >> (j * 8)) & 0xFF;
-                        let entry = NNZ_TABLE.table.get_unchecked(lookup as usize);
-                        let offsets = vec128_load(from_ref(entry).cast());
+                        let entry = NNZ_TABLE.table.as_ptr().add(lookup as usize);
+                        let offsets = vec128_load(entry.cast());
                         vec128_storeu(
-                            from_mut(nnz.get_unchecked_mut(nnz_count)).cast(),
+                            nnz.as_mut_ptr().add(nnz_count).cast(),
                             vec128_add(base, offsets),
                         );
                         nnz_count += u32::count_ones(lookup) as usize;
@@ -381,10 +383,10 @@ mod x86simd {
         output: &mut Align64<[f32; L2_SIZE]>,
     ) {
         // SAFETY: Breaking it down by unsafe operations:
-        // 1. get_unchecked[_mut]: We only ever index at most
+        // 1. get_unchecked[_mut] / .as[_mut]_ptr().add(): We only ever index at most
         // div_ceil(L1_PAIR_COUNT - 1, I16_CHUNK_SIZE * 2) + I16_CHUNK_SIZE + L1_PAIR_COUNT
         // into the `acc` array. This is in bounds, as `acc` has length L1_PAIR_COUNT * 2.
-        // Additionally, we only ever indexx at most div_ceil(L1_PAIR_COUNT - 1, I16_CHUNK_SIZE * 2) + L1_PAIR_COUNT
+        // Additionally, we only ever index at most div_ceil(L1_PAIR_COUNT - 1, I16_CHUNK_SIZE * 2) + L1_PAIR_COUNT
         // into the `ft_outputs` array. This is in bounds, as `ft_outputs` has length L1_PAIR_COUNT * 2.
         // 2. SIMD instructions: All of our loads and stores are aligned.
         unsafe {
@@ -417,13 +419,13 @@ mod x86simd {
                 // of the non-zero activation with the corresponding
                 // weight, and add it to the accumulator.
                 for k in 0..L2_SIZE / F32_CHUNK_SIZE {
-                    let sum = simd::load_i32(sums.get_unchecked(k * F32_CHUNK_SIZE));
+                    let sum = simd::load_i32(sums.as_ptr().add(k * F32_CHUNK_SIZE));
                     let weight_a =
-                        simd::load_i8(weights.get_unchecked(w_offset_a + k * U8_CHUNK_SIZE));
+                        simd::load_i8(weights.as_ptr().add(w_offset_a + k * U8_CHUNK_SIZE));
                     let weight_b =
-                        simd::load_i8(weights.get_unchecked(w_offset_b + k * U8_CHUNK_SIZE));
+                        simd::load_i8(weights.as_ptr().add(w_offset_b + k * U8_CHUNK_SIZE));
                     simd::store_i32(
-                        sums.get_unchecked_mut(k * F32_CHUNK_SIZE),
+                        sums.as_mut_ptr().add(k * F32_CHUNK_SIZE),
                         simd::mul_add_2xu8_to_i32(sum, input32_a, weight_a, input32_b, weight_b),
                     );
                 }
@@ -442,10 +444,10 @@ mod x86simd {
                 // of the non-zero activation with the corresponding
                 // weight, and add it to the accumulator.
                 for k in 0..L2_SIZE / F32_CHUNK_SIZE {
-                    let sum = simd::load_i32(sums.get_unchecked(k * F32_CHUNK_SIZE));
-                    let weight = simd::load_i8(weights.get_unchecked(w_offset + k * U8_CHUNK_SIZE));
+                    let sum = simd::load_i32(sums.as_ptr().add(k * F32_CHUNK_SIZE));
+                    let weight = simd::load_i8(weights.as_ptr().add(w_offset + k * U8_CHUNK_SIZE));
                     simd::store_i32(
-                        sums.get_unchecked_mut(k * F32_CHUNK_SIZE),
+                        sums.as_mut_ptr().add(k * F32_CHUNK_SIZE),
                         simd::mul_add_u8_to_i32(sum, input32, weight),
                     );
                 }
@@ -457,16 +459,16 @@ mod x86simd {
             let sum_mul = simd::splat_f32(L1_MUL);
             for i in 0..L2_SIZE / F32_CHUNK_SIZE {
                 // convert i32 to f32, multiplying by the quantisation constant
-                let bias = simd::load_f32(biases.get_unchecked(i * F32_CHUNK_SIZE));
+                let bias = simd::load_f32(biases.as_ptr().add(i * F32_CHUNK_SIZE));
                 let sum = simd::mul_add_f32(
-                    simd::i32_to_f32(simd::load_i32(sums.get_unchecked(i * F32_CHUNK_SIZE))),
+                    simd::i32_to_f32(simd::load_i32(sums.as_ptr().add(i * F32_CHUNK_SIZE))),
                     sum_mul,
                     bias,
                 );
                 // activate
                 let clipped = simd::min_f32(simd::max_f32(sum, zero), one);
                 let squared = simd::mul_f32(clipped, clipped);
-                simd::store_f32(output.get_unchecked_mut(i * F32_CHUNK_SIZE), squared);
+                simd::store_f32(output.as_mut_ptr().add(i * F32_CHUNK_SIZE), squared);
             }
         }
     }
@@ -479,7 +481,7 @@ mod x86simd {
         output: &mut Align64<[f32; L3_SIZE]>,
     ) {
         // SAFETY: Breaking it down by unsafe operations:
-        // 1. get_unchecked[_mut]: We only ever index at most (L3_SIZE / F32_CHUNK_SIZE - 1) * F32_CHUNK_SIZE
+        // 1. get_unchecked[_mut] / .as[_mut]_ptr().add(): We only ever index at most (L3_SIZE / F32_CHUNK_SIZE - 1) * F32_CHUNK_SIZE
         // into the `sums` and `biases` arrays. This is in bounds, as `sums` has length L3_SIZE and
         // `biases` has length L3_SIZE. We only ever index at most
         // (L2_SIZE - 1) * L3_SIZE + (L3_SIZE / F32_CHUNK_SIZE - 1) * F32_CHUNK_SIZE
@@ -495,11 +497,11 @@ mod x86simd {
                 let input_vec = simd::splat_f32(*inputs.get_unchecked(i));
                 for j in 0..L3_SIZE / F32_CHUNK_SIZE {
                     simd::store_f32(
-                        sums.get_unchecked_mut(j * F32_CHUNK_SIZE),
+                        sums.as_mut_ptr().add(j * F32_CHUNK_SIZE),
                         simd::mul_add_f32(
                             input_vec,
-                            simd::load_f32(weights.get_unchecked(i * L3_SIZE + j * F32_CHUNK_SIZE)),
-                            simd::load_f32(sums.get_unchecked(j * F32_CHUNK_SIZE)),
+                            simd::load_f32(weights.as_ptr().add(i * L3_SIZE + j * F32_CHUNK_SIZE)),
+                            simd::load_f32(sums.as_ptr().add(j * F32_CHUNK_SIZE)),
                         ),
                     );
                 }
@@ -510,13 +512,13 @@ mod x86simd {
             for i in 0..L3_SIZE / F32_CHUNK_SIZE {
                 let clipped = simd::min_f32(
                     simd::max_f32(
-                        simd::load_f32(sums.get_unchecked(i * F32_CHUNK_SIZE)),
+                        simd::load_f32(sums.as_ptr().add(i * F32_CHUNK_SIZE)),
                         simd::zero_f32(),
                     ),
                     one,
                 );
                 let squared = simd::mul_f32(clipped, clipped);
-                simd::store_f32(output.get_unchecked_mut(i * F32_CHUNK_SIZE), squared);
+                simd::store_f32(output.as_mut_ptr().add(i * F32_CHUNK_SIZE), squared);
             }
         }
     }
@@ -532,7 +534,7 @@ mod x86simd {
         // We multiply the weights by the inputs, and sum them up
         const NUM_SUMS: usize = AVX512CHUNK / F32_CHUNK_SIZE;
         // SAFETY: Breaking it down by unsafe operations:
-        // 1. get_unchecked[_mut]: We only ever index at most (L3_SIZE / F32_CHUNK_SIZE - 1) * F32_CHUNK_SIZE
+        // 1. get_unchecked[_mut] / .as[_mut]_ptr().add(): We only ever index at most (L3_SIZE / F32_CHUNK_SIZE - 1) * F32_CHUNK_SIZE
         // into the `weights` and `inputs` arrays. This is in bounds, as `weights` has length L3_SIZE and
         // `inputs` has length L3_SIZE.
         // 2. SIMD instructions: All of our loads and stores are aligned.
@@ -541,8 +543,8 @@ mod x86simd {
 
             // affine transform
             for i in 0..L3_SIZE / F32_CHUNK_SIZE {
-                let weight_vec = simd::load_f32(weights.get_unchecked(i * F32_CHUNK_SIZE));
-                let input_vec = simd::load_f32(inputs.get_unchecked(i * F32_CHUNK_SIZE));
+                let weight_vec = simd::load_f32(weights.as_ptr().add(i * F32_CHUNK_SIZE));
+                let input_vec = simd::load_f32(inputs.as_ptr().add(i * F32_CHUNK_SIZE));
                 sum_vecs[i % NUM_SUMS] =
                     simd::mul_add_f32(input_vec, weight_vec, sum_vecs[i % NUM_SUMS]);
             }


### PR DESCRIPTION
Fixed #296.

I'm not 100% sure that there's no dodgy references left, but I did fix all instances of `simd::(load|store)_*` and `vec128_(load|store)u` whose inputs didn't have the required provenance under Stacked Borrows.