### PR TITLE
Movepicker bonuses for in-out threats. 

### DIFF
--- a/src/chess/piecelayout.rs
+++ b/src/chess/piecelayout.rs
@@ -187,9 +187,9 @@ impl PieceLayout {
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
 pub struct Threats {
     pub all: SquareSet,
-    // pub pawn: SquareSet,
-    // pub minor: SquareSet,
-    // pub rook: SquareSet,
+    pub leq_pawn: SquareSet,
+    pub leq_minor: SquareSet,
+    pub leq_rook: SquareSet,
     pub checkers: SquareSet,
 }
 

--- a/src/movepicker.rs
+++ b/src/movepicker.rs
@@ -245,11 +245,31 @@ impl MovePicker {
                         }
                     }
                 }
-                PieceType::Knight
-                | PieceType::Bishop
-                | PieceType::Rook
-                | PieceType::Queen
-                | PieceType::King => {}
+                PieceType::Knight | PieceType::Bishop => {
+                    if pos.state.threats.leq_pawn.contains_square(from) {
+                        score += 4000;
+                    }
+                    if pos.state.threats.leq_pawn.contains_square(to) {
+                        score -= 4000;
+                    }
+                }
+                PieceType::Rook => {
+                    if pos.state.threats.leq_minor.contains_square(from) {
+                        score += 8000;
+                    }
+                    if pos.state.threats.leq_minor.contains_square(to) {
+                        score -= 8000;
+                    }
+                }
+                PieceType::Queen => {
+                    if pos.state.threats.leq_rook.contains_square(from) {
+                        score += 12000;
+                    }
+                    if pos.state.threats.leq_rook.contains_square(to) {
+                        score -= 12000;
+                    }
+                }
+                PieceType::King => {}
             }
 
             m.score = score;


### PR DESCRIPTION
```
Elo   | 2.15 +- 1.65 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.08 (-2.94, 2.94) [0.00, 3.00]
Games | N: 51830 W: 12919 L: 12599 D: 26312
Penta | [383, 6134, 12610, 6356, 432]
https://chess.swehosting.se/test/11715/
```