### PR TITLE
Only try NMP in expected Cut-nodes.

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -1111,7 +1111,8 @@ pub fn alpha_beta<NT: NodeType>(
         // null-move pruning.
         // if we can give the opponent a free move while retaining
         // a score above beta, we can prune the node.
-        if t.ss[height - 1].searching.is_some()
+        if cut_node
+            && t.ss[height - 1].searching.is_some()
             && depth > 2
             && static_eval
                 + i32::from(improving) * t.info.conf.nmp_improving_margin
@@ -1137,8 +1138,7 @@ pub fn alpha_beta<NT: NodeType>(
                 square: Square::A1,
             };
             t.board.make_nullmove();
-            let mut null_score =
-                -alpha_beta::<OffPV>(l_pv, t, nm_depth, -beta, -beta + 1, !cut_node);
+            let mut null_score = -alpha_beta::<OffPV>(l_pv, t, nm_depth, -beta, -beta + 1, false);
             t.board.unmake_nullmove();
             if t.info.stopped() {
                 return 0;


### PR DESCRIPTION
<pre class="long-statblock" id="long-statblock"><b>  ELO</b> +1.80 ± 1.43<br><b> CONF</b> 8.0+0.08 <span style="font-size: 12px; font-weight: 500;">1 <span style="letter-spacing: 0.5px; margin-right: -0.5px;">THREAD</span> 16 MB <span style="letter-spacing: 0.5px; margin-right: -0.5px;">CACHE</span></span><br><b>  LLR</b> +3.01 <span style="font-size: 12px; font-weight: 500;">−2.94<span style="margin-left: 4px; opacity: 50%;">LO</span> +2.94<span style="margin-left: 4px; opacity: 50%;">HI</span> BND <i>for</i> +0.00<span style="margin-left: 4px; opacity: 50%;">LO</span> +3.00<span style="margin-left: 4px; opacity: 50%;">HI</span> ELO</span><br><b>GAMES</b> <span style="margin-right: 0.2em;">60</span>898 (<span style="margin-right: 4px; opacity: 50%;"><span style="margin-right: 1px; letter-spacing: -1px;">²³<sup>·</sup>⁹</span><sup>%</sup></span><span style="margin-right: 0.2em;">14</span>554<span style="margin-left: 4px; opacity: 50%;">W</span> <span style="margin-right: 4px; opacity: 50%;"><span style="margin-right: 1px; letter-spacing: -1px;">⁵²<sup>·</sup>⁷</span><sup>%</sup></span><span style="margin-right: 0.2em;">32</span>106<span style="margin-left: 4px; opacity: 50%;">D</span> <span style="margin-right: 4px; opacity: 50%;"><span style="margin-right: 1px; letter-spacing: -1px;">²³<sup>·</sup>⁴</span><sup>%</sup></span><span style="margin-right: 0.2em;">14</span>238<span style="margin-left: 4px; opacity: 50%;">L</span>)<br><b>PENTA</b> 222<span style="margin-left: 1px; opacity: 50%;"><sup style="margin-right: -1px;">+</sup>²</span> 7407<span style="margin-left: 1px; opacity: 50%;"><sup style="margin-right: -1px;">+</sup>¹</span> <span style="margin-right: 0.2em;">15</span>491<span style="margin-left: 1px; opacity: 50%;">⁰</span> 7123<span style="margin-left: 1px; opacity: 50%;"><sup style="margin-right: -1px;">−</sup>¹</span> 206<span style="margin-left: 1px; opacity: 50%;"><sup style="margin-right: -1px;">−</sup>²</span></pre>