### PR TITLE
Factor capture history by threats.

### DIFF
--- a/src/historytable.rs
+++ b/src/historytable.rs
@@ -2,7 +2,7 @@ use std::ops::{Deref, DerefMut};
 
 use crate::{
     chess::{
-        piece::{Colour, Piece, PieceType},
+        piece::{Colour, Piece},
         types::{ContHistIndex, Square},
     },
     search::parameters::Config,
@@ -190,7 +190,7 @@ impl DerefMut for ThreatsHistoryTable {
 
 #[repr(transparent)]
 pub struct CaptureHistoryTable {
-    table: [HistoryTable; 6],
+    table: [[HistoryTable; 6]; 2],
 }
 
 impl CaptureHistoryTable {
@@ -210,21 +210,23 @@ impl CaptureHistoryTable {
     }
 
     pub fn clear(&mut self) {
-        self.table.iter_mut().for_each(HistoryTable::clear);
+        self.table
+            .iter_mut()
+            .flatten()
+            .for_each(HistoryTable::clear);
     }
 
     pub fn age_entries(&mut self) {
         debug_assert!(!self.table.is_empty());
-        self.table.iter_mut().for_each(HistoryTable::age_entries);
-    }
-
-    pub fn get_mut(&mut self, piece: Piece, sq: Square, capture: PieceType) -> &mut i16 {
-        &mut self.table[capture][piece][sq]
+        self.table
+            .iter_mut()
+            .flatten()
+            .for_each(HistoryTable::age_entries);
     }
 }
 
 impl Deref for CaptureHistoryTable {
-    type Target = [HistoryTable; 6];
+    type Target = [[HistoryTable; 6]; 2];
 
     fn deref(&self) -> &Self::Target {
         &self.table

--- a/src/movepicker.rs
+++ b/src/movepicker.rs
@@ -277,9 +277,11 @@ impl MovePicker {
     pub fn score_captures(t: &ThreadData, moves: &mut [MoveListEntry]) {
         const MVV_SCORE: [i32; 6] = [0, 2400, 2400, 4800, 9600, 0];
 
+        let threats = t.board.state.threats.all;
         for m in moves {
             let from = m.mov.from();
             let to = m.mov.to();
+            let threat_to = threats.contains_square(to);
             let piece = t.board.state.mailbox[from].unwrap();
             let capture = history::caphist_piece_type(&t.board, m.mov);
 
@@ -288,7 +290,7 @@ impl MovePicker {
             let mut score = WINNING_CAPTURE_BONUS;
 
             score += MVV_SCORE[capture];
-            score += i32::from(t.tactical_history[capture][piece][to]);
+            score += i32::from(t.tactical_history[usize::from(threat_to)][capture][piece][to]);
 
             m.score = score;
         }


### PR DESCRIPTION
<pre class="long-statblock" id="long-statblock"><b>  ELO</b> +1.78 ± 1.41<br><b> CONF</b> 40.0+0.40 <span style="font-size: 12px; font-weight: 500;">1 <span style="letter-spacing: 0.5px; margin-right: -0.5px;">THREAD</span> 128 MB <span style="letter-spacing: 0.5px; margin-right: -0.5px;">CACHE</span></span><br><b>  LLR</b> +2.97 <span style="font-size: 12px; font-weight: 500;">−2.94<span style="margin-left: 4px; opacity: 50%;">LO</span> +2.94<span style="margin-left: 4px; opacity: 50%;">HI</span> BND <i>for</i> +0.00<span style="margin-left: 4px; opacity: 50%;">LO</span> +3.00<span style="margin-left: 4px; opacity: 50%;">HI</span> ELO</span><br><b>GAMES</b> <span style="margin-right: 0.2em;">56</span>106 (<span style="margin-right: 4px; opacity: 50%;"><span style="margin-right: 1px; letter-spacing: -1px;">²³<sup>·</sup>¹</span><sup>%</sup></span><span style="margin-right: 0.2em;">12</span>958<span style="margin-left: 4px; opacity: 50%;">W</span> <span style="margin-right: 4px; opacity: 50%;"><span style="margin-right: 1px; letter-spacing: -1px;">⁵⁴<sup>·</sup>³</span><sup>%</sup></span><span style="margin-right: 0.2em;">30</span>477<span style="margin-left: 4px; opacity: 50%;">D</span> <span style="margin-right: 4px; opacity: 50%;"><span style="margin-right: 1px; letter-spacing: -1px;">²²<sup>·</sup>⁶</span><sup>%</sup></span><span style="margin-right: 0.2em;">12</span>671<span style="margin-left: 4px; opacity: 50%;">L</span>)<br><b>PENTA</b> 68<span style="margin-left: 1px; opacity: 50%;"><sup style="margin-right: -1px;">+</sup>²</span> 6598<span style="margin-left: 1px; opacity: 50%;"><sup style="margin-right: -1px;">+</sup>¹</span> <span style="margin-right: 0.2em;">14</span>995<span style="margin-left: 1px; opacity: 50%;">⁰</span> 6337<span style="margin-left: 1px; opacity: 50%;"><sup style="margin-right: -1px;">−</sup>¹</span> 55<span style="margin-left: 1px; opacity: 50%;"><sup style="margin-right: -1px;">−</sup>²</span></pre>