### PR TITLE
Don't age history tables.

### DIFF
--- a/src/historytable.rs
+++ b/src/historytable.rs
@@ -9,8 +9,6 @@ use crate::{
     util::BOARD_N_SQUARES,
 };
 
-const AGEING_DIVISOR: i16 = 2;
-
 pub fn main_history_bonus(conf: &Config, depth: i32) -> i32 {
     i32::min(
         conf.main_history_bonus_mul * depth + conf.main_history_bonus_offset,
@@ -108,14 +106,6 @@ impl HistoryTable {
         }
     }
 
-    pub fn age_entries(&mut self) {
-        debug_assert!(!self.table.is_empty());
-        self.table
-            .iter_mut()
-            .flatten()
-            .for_each(|x| *x /= AGEING_DIVISOR);
-    }
-
     pub fn get_mut(&mut self, piece: Piece, sq: Square) -> &mut i16 {
         &mut self[piece][sq]
     }
@@ -153,14 +143,6 @@ impl ThreatsHistoryTable {
             .iter_mut()
             .flatten()
             .for_each(HistoryTable::clear);
-    }
-
-    pub fn age_entries(&mut self) {
-        debug_assert!(!self.table.is_empty());
-        self.table
-            .iter_mut()
-            .flatten()
-            .for_each(HistoryTable::age_entries);
     }
 
     pub fn get_mut(
@@ -215,14 +197,6 @@ impl CaptureHistoryTable {
             .flatten()
             .for_each(HistoryTable::clear);
     }
-
-    pub fn age_entries(&mut self) {
-        debug_assert!(!self.table.is_empty());
-        self.table
-            .iter_mut()
-            .flatten()
-            .for_each(HistoryTable::age_entries);
-    }
 }
 
 impl Deref for CaptureHistoryTable {
@@ -265,14 +239,6 @@ impl DoubleHistoryTable {
             .iter_mut()
             .flatten()
             .for_each(HistoryTable::clear);
-    }
-
-    pub fn age_entries(&mut self) {
-        debug_assert!(!self.table.is_empty());
-        self.table
-            .iter_mut()
-            .flatten()
-            .for_each(HistoryTable::age_entries);
     }
 
     pub fn get_index_mut(&mut self, index: ContHistIndex) -> &mut HistoryTable {

--- a/src/threadlocal.rs
+++ b/src/threadlocal.rs
@@ -140,9 +140,6 @@ impl<'a> ThreadData<'a> {
     }
 
     pub fn set_up_for_search(&mut self) {
-        self.main_history.age_entries();
-        self.tactical_history.age_entries();
-        self.continuation_history.age_entries();
         self.killer_move_table.fill(None);
         self.depth = 0;
         self.completed = 0;


### PR DESCRIPTION
<pre>
<b>  ELO</b> −0.18 ± 1.08 (−1.26<sub>LO</sub> +0.90<sub>HI</sub>)
<b> CONF</b> 8.0+0.08 (1 THREAD 16 MB CACHE)
<b>  LLR</b> +3.02 (−2.94<sub>LO</sub> +2.94<sub>HI</sub> BND <i>for</i> −3.00<sub>LO</sub> +0.00<sub>HI</sub> ELO)
<b>GAMES</b> 105242 (25057<sub>W</sub><sup>23.8%</sup> 55074<sub>D</sub><sup>52.3%</sup> 25111<sub>L</sub><sup>23.9%</sup>)
<b>PENTA</b> 399<sub>+2</sub> 12318<sub>+1</sub> 27127<sub>+0</sub> 12384<sub>−1</sub> 393<sub>−2</sub>
</pre>