### PR TITLE
Prevent RFP when contraindicated by TT.

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -1040,7 +1040,8 @@ pub fn alpha_beta<NT: NodeType>(
         // if the static eval is too low, check if qsearch can beat alpha.
         // if it can't, we can prune the node.
         if alpha < 2000
-            && eval < alpha - t.info.conf.razoring_coeff_0 - t.info.conf.razoring_coeff_1 * depth
+            && static_eval
+                < alpha - t.info.conf.razoring_coeff_0 - t.info.conf.razoring_coeff_1 * depth
         {
             let v = quiescence::<OffPV>(pv, t, alpha, beta);
             if v <= alpha {
@@ -1055,11 +1056,11 @@ pub fn alpha_beta<NT: NodeType>(
         if !t.ss[height].ttpv
             && depth < 9
             && eval >= beta
-            && eval - rfp_margin(&t.board, &t.info, depth, improving, correction) >= beta
+            && static_eval - rfp_margin(&t.board, &t.info, depth, improving, correction) >= beta
             && (tt_move.is_none() || tt_capture)
             && beta > -MINIMUM_TB_WIN_SCORE
         {
-            return beta + (eval - beta) / 3;
+            return beta + (static_eval - beta) / 3;
         }
 
         // null-move pruning.

--- a/src/search.rs
+++ b/src/search.rs
@@ -932,6 +932,7 @@ pub fn alpha_beta<NT: NodeType>(
         correction = t.correction();
         static_eval = adj_shuffle(t, raw_eval, clock) + correction;
         if tte.value != VALUE_NONE
+            && !is_game_theoretic_score(tte.value)
             && match tte.bound {
                 Bound::Upper => tte.value < static_eval,
                 Bound::Lower => tte.value > static_eval,

--- a/src/search.rs
+++ b/src/search.rs
@@ -900,22 +900,25 @@ pub fn alpha_beta<NT: NodeType>(
 
     let raw_eval;
     let static_eval;
+    let eval;
     let correction;
 
     if in_check {
         // when we're in check, it could be checkmate, so it's unsound to use evaluate().
         raw_eval = VALUE_NONE;
         static_eval = VALUE_NONE;
+        eval = VALUE_NONE;
         correction = 0;
     } else if excluded.is_some() {
         // if we're in a singular-verification search, we already have the static eval.
         // we can set raw_eval to whatever we like, because we're not going to be saving it.
         raw_eval = VALUE_NONE;
-        static_eval = t.ss[height].eval;
+        static_eval = t.ss[height].static_eval;
+        eval = t.ss[height].eval;
         correction = 0;
         t.nnue.hint_common_access(&t.board, t.nnue_params);
-    } else if let Some(TTHit { eval: tt_eval, .. }) = &tt_hit {
-        let v = *tt_eval; // if we have a TT hit, check the cached TT eval.
+    } else if let Some(tte) = &tt_hit {
+        let v = tte.eval; // if we have a TT hit, check the cached TT eval.
         if v == VALUE_NONE {
             // regenerate the static eval if it's VALUE_NONE.
             raw_eval = evaluate(t, t.info.nodes.get_local());
@@ -928,6 +931,18 @@ pub fn alpha_beta<NT: NodeType>(
         }
         correction = t.correction();
         static_eval = adj_shuffle(t, raw_eval, clock) + correction;
+        if tte.value != VALUE_NONE
+            && match tte.bound {
+                Bound::Upper => tte.value < static_eval,
+                Bound::Lower => tte.value > static_eval,
+                Bound::Exact => true,
+                Bound::None => false,
+            }
+        {
+            eval = tte.value;
+        } else {
+            eval = static_eval;
+        }
     } else {
         // otherwise, use the static evaluation.
         raw_eval = evaluate(t, t.info.nodes.get_local());
@@ -947,15 +962,17 @@ pub fn alpha_beta<NT: NodeType>(
 
         correction = t.correction();
         static_eval = adj_shuffle(t, raw_eval, clock) + correction;
+        eval = static_eval;
     }
 
-    t.ss[height].eval = static_eval;
+    t.ss[height].static_eval = static_eval;
+    t.ss[height].eval = eval;
 
     // value-difference based policy update.
     if !NT::ROOT {
         let ss_prev = &t.ss[height - 1];
         if let Some(mov) = ss_prev.searching {
-            if ss_prev.eval != VALUE_NONE
+            if ss_prev.static_eval != VALUE_NONE
                 && static_eval != VALUE_NONE
                 && !ss_prev.searching_tactical
             {
@@ -964,7 +981,8 @@ pub fn alpha_beta<NT: NodeType>(
                 let moved = t.board.state.mailbox[to].expect("Cannot fail, move has been made.");
                 debug_assert_eq!(moved.colour(), !t.board.turn());
                 let threats = t.board.history().last().unwrap().threats.all;
-                let improvement = -(ss_prev.eval + static_eval) + t.info.conf.eval_policy_offset;
+                let improvement =
+                    -(ss_prev.static_eval + static_eval) + t.info.conf.eval_policy_offset;
                 let delta = i32::clamp(
                     improvement * t.info.conf.eval_policy_improvement_scale / 32,
                     -t.info.conf.eval_policy_update_max,
@@ -982,10 +1000,10 @@ pub fn alpha_beta<NT: NodeType>(
     // neutral with regards to the evaluation.
     let improving = if in_check {
         false
-    } else if height >= 2 && t.ss[height - 2].eval != VALUE_NONE {
-        static_eval > t.ss[height - 2].eval
-    } else if height >= 4 && t.ss[height - 4].eval != VALUE_NONE {
-        static_eval > t.ss[height - 4].eval
+    } else if height >= 2 && t.ss[height - 2].static_eval != VALUE_NONE {
+        static_eval > t.ss[height - 2].static_eval
+    } else if height >= 4 && t.ss[height - 4].static_eval != VALUE_NONE {
+        static_eval > t.ss[height - 4].static_eval
     } else {
         true
     };
@@ -1005,15 +1023,15 @@ pub fn alpha_beta<NT: NodeType>(
     // whole-node techniques:
     if !NT::ROOT && !NT::PV && !in_check && excluded.is_none() {
         if t.ss[height - 1].reduction >= t.info.conf.hindsight_ext_depth
-            && static_eval + t.ss[height - 1].eval < 0
+            && static_eval + t.ss[height - 1].static_eval < 0
         {
             depth += 1;
         }
 
         if depth >= 2
             && t.ss[height - 1].reduction >= t.info.conf.hindsight_red_depth
-            && t.ss[height - 1].eval != VALUE_NONE
-            && static_eval + t.ss[height - 1].eval > t.info.conf.hindsight_red_eval
+            && t.ss[height - 1].static_eval != VALUE_NONE
+            && static_eval + t.ss[height - 1].static_eval > t.info.conf.hindsight_red_eval
         {
             depth -= 1;
         }
@@ -1022,8 +1040,7 @@ pub fn alpha_beta<NT: NodeType>(
         // if the static eval is too low, check if qsearch can beat alpha.
         // if it can't, we can prune the node.
         if alpha < 2000
-            && static_eval
-                < alpha - t.info.conf.razoring_coeff_0 - t.info.conf.razoring_coeff_1 * depth
+            && eval < alpha - t.info.conf.razoring_coeff_0 - t.info.conf.razoring_coeff_1 * depth
         {
             let v = quiescence::<OffPV>(pv, t, alpha, beta);
             if v <= alpha {
@@ -1037,11 +1054,12 @@ pub fn alpha_beta<NT: NodeType>(
         // this is a generalisation of stand_pat in quiescence search.
         if !t.ss[height].ttpv
             && depth < 9
-            && static_eval - rfp_margin(&t.board, &t.info, depth, improving, correction) >= beta
+            && eval >= beta
+            && eval - rfp_margin(&t.board, &t.info, depth, improving, correction) >= beta
             && (tt_move.is_none() || tt_capture)
             && beta > -MINIMUM_TB_WIN_SCORE
         {
-            return beta + (static_eval - beta) / 3;
+            return beta + (eval - beta) / 3;
         }
 
         // null-move pruning.

--- a/src/stack.rs
+++ b/src/stack.rs
@@ -3,6 +3,7 @@ use crate::chess::{chessmove::Move, types::ContHistIndex};
 #[derive(Default, Clone)]
 #[allow(clippy::module_name_repetitions)]
 pub struct StackEntry {
+    pub static_eval: i32,
     pub eval: i32,
     pub excluded: Option<Move>,
     pub best_move: Option<Move>,


### PR DESCRIPTION
<pre>
<b>  ELO</b> +1.82 ± 1.45 (+0.37<sub>LO</sub> +3.27<sub>HI</sub>)
<b> CONF</b> 8.0+0.08 (1 THREAD 16 MB CACHE)
<b>  LLR</b> +2.99 (−2.94<sub>LO</sub> +2.94<sub>HI</sub> BND <i>for</i> +0.00<sub>LO</sub> +3.00<sub>HI</sub> ELO)
<b>GAMES</b> 61070 (14899<sub>W</sub><sup>24.4%</sup> 31592<sub>D</sub><sup>51.7%</sup> 14579<sub>L</sub><sup>23.9%</sup>)
<b>PENTA</b> 331<sub>+2</sub> 7296<sub>+1</sub> 15559<sub>+0</sub> 7060<sub>−1</sub> 289<sub>−2</sub>
</pre>