### PR TITLE
Perform LMR earlier in PV nodes.

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -1383,7 +1383,7 @@ pub fn alpha_beta<NT: NodeType>(
                 -alpha_beta::<NT::Next>(l_pv, t, new_depth, -beta, -alpha, !NT::PV && !cut_node);
         } else {
             // calculation of LMR stuff
-            let r = if depth > 2 && moves_made > (1 + usize::from(NT::PV)) {
+            let r = if depth > 2 && moves_made > (1 + usize::from(NT::ROOT)) {
                 let mut r = t.info.lm_table.lm_reduction(depth, moves_made);
                 // reduce more on non-PV nodes
                 r += i32::from(!NT::PV) * t.info.conf.lmr_non_pv_mul;


### PR DESCRIPTION
<pre>
<b>  ELO</b> +2.19 ± 1.69 (+0.50<sub>LO</sub> +3.88<sub>HI</sub>)
<b> CONF</b> 8.0+0.08 (1 THREAD 16 MB CACHE)
<b>  LLR</b> +2.96 (−2.94<sub>LO</sub> +2.94<sub>HI</sub> BND <i>for</i> +0.00<sub>LO</sub> +3.00<sub>HI</sub> ELO)
<b>GAMES</b> 44762 (10921<sub>W</sub><sup>24.4%</sup> 23202<sub>D</sub><sup>51.8%</sup> 10639<sub>L</sub><sup>23.8%</sup>)
<b>PENTA</b> 205<sub>+2</sub> 5518<sub>+1</sub> 11212<sub>+0</sub> 5246<sub>−1</sub> 200<sub>−2</sub>
</pre>