### PR TITLE
Fix PV truncation; false TB scores.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,9 @@ memmap2 = "0.9.5"
 # for deconflicting shared weights
 fxhash = "0.2.1"
 
+# what it says on the tin
+term_size = "0.3.2"
+
 # for coloured terminal output
 [target.'cfg(target_os = "windows")'.dependencies.windows-sys]
 version = "0.60"
@@ -76,6 +79,6 @@ features = [
 [profile.release]
 lto = true
 codegen-units = 1
-panic = "abort"
-strip = true
-# debug = true
+# panic = "abort"
+# strip = true
+debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,6 @@ features = [
 [profile.release]
 lto = true
 codegen-units = 1
-# panic = "abort"
-# strip = true
-debug = true
+panic = "abort"
+strip = true
+# debug = true

--- a/src/chess/chessmove.rs
+++ b/src/chess/chessmove.rs
@@ -127,8 +127,10 @@ impl Move {
     /// Handles castling moves, which are a bit weird.
     pub fn history_to_square(self) -> Square {
         if self.is_castle() {
-            let to_rank = self.from().rank();
-            if self.to() > self.from() {
+            let to = self.to();
+            let from = self.from();
+            let to_rank = from.rank();
+            if to > from {
                 // kingside castling, king goes to the G file
                 Square::from_rank_file(to_rank, File::G)
             } else {

--- a/src/datagen.rs
+++ b/src/datagen.rs
@@ -34,7 +34,7 @@ use crate::{
         types::Square,
     },
     datagen::dataformat::Game,
-    evaluation::{is_game_theoretic_score, is_mate_score},
+    evaluation::{is_decisive, is_mate_score},
     nnue::network::NNUEParams,
     search::{search_position, static_exchange_eval},
     tablebases::{self, probe::WDL},
@@ -556,7 +556,7 @@ fn generate_on_thread<'a>(
             if draw_adj_counter >= 12 {
                 break GameOutcome::Draw(DrawType::Adjudication);
             }
-            if is_game_theoretic_score(score) {
+            if is_decisive(score) {
                 // if the score is game theoretic, we don't want to play out the rest of the game
                 break match (score > 0, is_mate_score(score)) {
                     (true, true) => GameOutcome::WhiteWin(WinType::Mate),

--- a/src/evaluation.rs
+++ b/src/evaluation.rs
@@ -43,7 +43,7 @@ pub const fn tb_loss_in(ply: usize) -> i32 {
 
 /// A threshold over which scores must be mate.
 #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
-const MINIMUM_MATE_SCORE: i32 = MATE_SCORE - MAX_DEPTH as i32;
+pub const MINIMUM_MATE_SCORE: i32 = MATE_SCORE - MAX_DEPTH as i32;
 /// A threshold over which scores must be a TB win (or mate).
 #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
 pub const MINIMUM_TB_WIN_SCORE: i32 = TB_WIN_SCORE - MAX_DEPTH as i32;
@@ -108,7 +108,7 @@ pub fn evaluate_nnue(t: &ThreadData) -> i32 {
     // this basically never comes up, but the network will
     // occasionally output OOB values in crazy positions with
     // massive material imbalances.
-    v.clamp(-MINIMUM_TB_WIN_SCORE + 1, MINIMUM_TB_WIN_SCORE - 1)
+    v.clamp(-MINIMUM_TB_WIN_SCORE + 1024, MINIMUM_TB_WIN_SCORE - 1024)
 }
 
 pub fn evaluate(t: &mut ThreadData, nodes: u64) -> i32 {

--- a/src/evaluation.rs
+++ b/src/evaluation.rs
@@ -18,7 +18,7 @@ use crate::{
 /// To recover depth-to-mate, we subtract depth (ply) from this value.
 /// e.g. if white has a mate in two ply, the output from a depth-5 search will be
 /// two less than `MATE_SCORE`.
-pub const MATE_SCORE: i32 = i16::MAX as i32 - 300;
+pub const MATE_SCORE: i32 = i16::MAX as i32 - 367;
 pub const fn mate_in(ply: usize) -> i32 {
     #![allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
     debug_assert!(ply <= MAX_DEPTH);
@@ -43,15 +43,15 @@ pub const fn tb_loss_in(ply: usize) -> i32 {
 
 /// A threshold over which scores must be mate.
 #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
-pub const MINIMUM_MATE_SCORE: i32 = MATE_SCORE - MAX_DEPTH as i32;
+pub const MINIMUM_MATE_SCORE: i32 = MATE_SCORE - 2 * MAX_DEPTH as i32 - 44;
 /// A threshold over which scores must be a TB win (or mate).
 #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
-pub const MINIMUM_TB_WIN_SCORE: i32 = TB_WIN_SCORE - MAX_DEPTH as i32;
+pub const MINIMUM_TB_WIN_SCORE: i32 = TB_WIN_SCORE - 2 * MAX_DEPTH as i32 - 44;
 
 pub const fn is_mate_score(score: i32) -> bool {
     score.abs() >= MINIMUM_MATE_SCORE
 }
-pub const fn is_game_theoretic_score(score: i32) -> bool {
+pub const fn is_decisive(score: i32) -> bool {
     score.abs() >= MINIMUM_TB_WIN_SCORE
 }
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -42,12 +42,23 @@ macro_rules! track {
             )]
             static TOTAL: std::sync::atomic::AtomicI64 = std::sync::atomic::AtomicI64::new(0);
             static COUNT: std::sync::atomic::AtomicI64 = std::sync::atomic::AtomicI64::new(0);
-            TOTAL.fetch_add($v as i64, std::sync::atomic::Ordering::Relaxed);
+            static MAX: std::sync::atomic::AtomicI64 = std::sync::atomic::AtomicI64::new(i64::MIN);
+            static MIN: std::sync::atomic::AtomicI64 = std::sync::atomic::AtomicI64::new(i64::MAX);
+            let v = $v as i64;
+            MAX.fetch_max(v, std::sync::atomic::Ordering::Relaxed);
+            MIN.fetch_min(v, std::sync::atomic::Ordering::Relaxed);
+            TOTAL.fetch_add(v, std::sync::atomic::Ordering::Relaxed);
             let count = COUNT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-            if count % 2048 == 0 {
+            if count % 8192 == 0 {
                 let total = TOTAL.load(std::sync::atomic::Ordering::Relaxed);
                 let avg = total as f64 / count as f64;
                 println!("average value of {}: {}", stringify!($v), avg);
+                println!(
+                    "min/max value of {}: {}/{}",
+                    stringify!($v),
+                    MIN.load(std::sync::atomic::Ordering::Relaxed),
+                    MAX.load(std::sync::atomic::Ordering::Relaxed)
+                );
             }
             // pass-through
             $v

--- a/src/search.rs
+++ b/src/search.rs
@@ -810,6 +810,7 @@ pub fn alpha_beta<NT: NodeType>(
     let tt_hit = if excluded.is_none() {
         if let Some(hit) = t.tt.probe(key, height, clock) {
             if !NT::PV
+                && hit.value != VALUE_NONE
                 && hit.depth >= depth + i32::from(hit.value >= beta)
                 && clock < 80
                 && (hit.bound == Bound::Exact

--- a/src/search.rs
+++ b/src/search.rs
@@ -596,9 +596,10 @@ pub fn quiescence<NT: NodeType>(
         let (tt_flag, tt_value) = tt_hit
             .as_ref()
             .map_or((Bound::None, VALUE_NONE), |tte| (tte.bound, tte.value));
-        if tt_flag == Bound::Exact
-            || tt_flag == Bound::Upper && tt_value < adj_eval
-            || tt_flag == Bound::Lower && tt_value > adj_eval
+        if !is_decisive(tt_value)
+            && (tt_flag == Bound::Exact
+                || tt_flag == Bound::Upper && tt_value < adj_eval
+                || tt_flag == Bound::Lower && tt_value > adj_eval)
         {
             stand_pat = tt_value;
         } else {

--- a/src/search.rs
+++ b/src/search.rs
@@ -1069,7 +1069,6 @@ pub fn alpha_beta<NT: NodeType>(
         if cut_node
             && t.ss[height - 1].searching.is_some()
             && depth > 2
-            && !is_decisive(beta)
             && static_eval
                 + i32::from(improving) * t.info.conf.nmp_improving_margin
                 + depth * t.info.conf.nmp_depth_mul
@@ -1105,7 +1104,7 @@ pub fn alpha_beta<NT: NodeType>(
                     null_score = beta;
                 }
                 // unconditionally cutoff if we're just too shallow.
-                if depth < 12 {
+                if depth < 12 && !is_decisive(beta) {
                     return null_score;
                 }
                 // verify that it's *actually* fine to prune,
@@ -1117,8 +1116,7 @@ pub fn alpha_beta<NT: NodeType>(
                 let veri_score = alpha_beta::<OffPV>(l_pv, t, nm_depth, beta - 1, beta, false);
                 t.unban_nmp_for(t.board.turn());
                 if veri_score >= beta {
-                    // TODO: test replacing with `return veri_score;`
-                    return null_score;
+                    return veri_score;
                 }
             }
         }

--- a/src/search.rs
+++ b/src/search.rs
@@ -1104,7 +1104,7 @@ pub fn alpha_beta<NT: NodeType>(
                     null_score = beta;
                 }
                 // unconditionally cutoff if we're just too shallow.
-                if depth < 12 && !is_decisive(beta) {
+                if depth < 12 {
                     return null_score;
                 }
                 // verify that it's *actually* fine to prune,
@@ -1116,6 +1116,7 @@ pub fn alpha_beta<NT: NodeType>(
                 let veri_score = alpha_beta::<OffPV>(l_pv, t, nm_depth, beta - 1, beta, false);
                 t.unban_nmp_for(t.board.turn());
                 if veri_score >= beta {
+                    // TODO: test replacing with `return veri_score;`
                     return null_score;
                 }
             }

--- a/src/search.rs
+++ b/src/search.rs
@@ -1326,6 +1326,7 @@ pub fn alpha_beta<NT: NodeType>(
             } = tt_hit.unwrap();
             let r_beta = singularity_margin(tt_value, depth);
             let r_depth = (depth - 1) / 2;
+
             t.ss[t.board.height()].excluded = Some(m);
             let value = alpha_beta::<OffPV>(
                 &mut PVariation::default(),
@@ -1336,7 +1337,8 @@ pub fn alpha_beta<NT: NodeType>(
                 cut_node,
             );
             t.ss[t.board.height()].excluded = None;
-            if value >= r_beta && r_beta >= beta {
+
+            if value != VALUE_NONE && value >= r_beta && r_beta >= beta {
                 // multi-cut: if a move other than the best one beats beta,
                 // then we can cut with relatively high confidence.
                 return value;

--- a/src/search.rs
+++ b/src/search.rs
@@ -1341,7 +1341,7 @@ pub fn alpha_beta<NT: NodeType>(
             if value != VALUE_NONE && value >= r_beta && r_beta >= beta {
                 // multi-cut: if a move other than the best one beats beta,
                 // then we can cut with relatively high confidence.
-                return value;
+                return singularity_margin(tt_value, depth);
             }
 
             if value == VALUE_NONE {

--- a/src/searchinfo.rs
+++ b/src/searchinfo.rs
@@ -131,7 +131,7 @@ impl<'a> SearchInfo<'a> {
     }
 
     pub fn skip_print(&self) -> bool {
-        self.clock.time_since_start().as_millis() < 50
+        self.clock.is_dynamic() && self.clock.time_since_start().as_millis() < 50
     }
 
     pub fn stopped(&self) -> bool {

--- a/src/transpositiontable.rs
+++ b/src/transpositiontable.rs
@@ -385,16 +385,9 @@ impl TTView<'_> {
             || flag == Bound::Exact && tte.info.flag() != Bound::Exact
             || insert_priority * 3 >= record_prority * 2
         {
-            let o_score = score;
             let score = normalise_gt_truth_score(score, ply).try_into().expect(
                 "attempted to store a score with value outwith [i16::MIN, i16::MAX] in the transposition table",
             );
-            if score == -32385 {
-                eprintln!("wtf");
-                eprintln!("original score: {o_score}");
-                eprintln!("ply: {ply}");
-                // panic!();
-            }
             let write = TTEntry {
                 key,
                 m: best_move,
@@ -425,13 +418,6 @@ impl TTView<'_> {
             }
 
             let value = reconstruct_gt_truth_score(entry.score.into(), ply, clock);
-            if value == -32338 {
-                eprintln!("wtf");
-                eprintln!("score: {}", entry.score);
-                eprintln!("ply: {ply}");
-                eprintln!("clock: {clock}");
-                // panic!();
-            }
 
             return Some(TTHit {
                 mov: entry.m,

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -35,7 +35,7 @@ use crate::{
     },
     cuckoo,
     errors::{FenParseError, MoveParseError},
-    evaluation::{MATE_SCORE, TB_WIN_SCORE, evaluate, is_game_theoretic_score, is_mate_score},
+    evaluation::{MATE_SCORE, TB_WIN_SCORE, evaluate, is_decisive, is_mate_score},
     nnue::{
         self,
         network::{self, NNUEParams},
@@ -485,7 +485,7 @@ impl Display for ScoreFormatWrapper {
             } else {
                 write!(f, "mate -{moves_to_mate}")
             }
-        } else if is_game_theoretic_score(self.0) {
+        } else if is_decisive(self.0) {
             write!(f, "cp {}", self.0)
         } else {
             write!(f, "cp {}", self.0 * 100 / NORMALISE_TO_PAWN_VALUE)
@@ -520,7 +520,7 @@ impl Display for PrettyScoreFormatWrapper {
             } else {
                 write!(f, "  #-{moves_to_mate:<2}")?;
             }
-        } else if is_game_theoretic_score(white_pov) {
+        } else if is_decisive(white_pov) {
             let plies_to_tb = TB_WIN_SCORE - white_pov.abs();
             if white_pov > 0 {
                 write!(f, " +TB{plies_to_tb:<2}")?;
@@ -529,6 +529,7 @@ impl Display for PrettyScoreFormatWrapper {
             }
         } else {
             let white_pov = white_pov * 100 / NORMALISE_TO_PAWN_VALUE;
+            let white_pov = white_pov.clamp(-9999, 9999);
             if white_pov == 0 {
                 // same as below, but with no sign
                 write!(f, "{:6.2}", f64::from(white_pov) / 100.0)?;

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -1143,7 +1143,7 @@ impl Display for PrettyUciWdlFormat {
         let wdl_l = (f64::from(wdl_l) / 10.0).round() as i32;
         write!(
             f,
-            "\u{001b}[38;5;243m{wdl_w:3.0}%W {wdl_d:3.0}%D {wdl_l:3.0}%L\u{001b}[0m",
+            "\u{001b}[38;5;243m{wdl_w:3.0}W {wdl_d:3.0}D {wdl_l:3.0}L\u{001b}[0m",
         )
     }
 }
@@ -1153,4 +1153,21 @@ pub fn format_wdl(eval: i32, ply: usize) -> impl Display {
 }
 pub fn pretty_format_wdl(eval: i32, ply: usize) -> impl Display {
     PrettyUciWdlFormat { eval, ply }
+}
+
+struct PrettyCounterFormat(u64);
+impl Display for PrettyCounterFormat {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        #![allow(clippy::match_overlapping_arm)]
+        match self.0 {
+            ..1_000 => write!(f, "{:>4}", self.0),
+            ..1_000_000 => write!(f, "{:>3}K", self.0 / 1_000),
+            ..1_000_000_000 => write!(f, "{:>3}M", self.0 / 1_000_000),
+            ..1_000_000_000_000 => write!(f, "{:>3}G", self.0 / 1_000_000_000),
+            _ => write!(f, "{:>3}T", self.0 / 1_000_000_000_000),
+        }
+    }
+}
+pub const fn pretty_format_counter(v: u64) -> impl Display {
+    PrettyCounterFormat(v)
 }


### PR DESCRIPTION
Yes, darling, I know that this is terribly poor form. I'll make it up to you someday.
<pre>
https://ob.expositor.dev/test/130/
<b>  ELO</b> +1.15 ± 2.86 (−1.71<sub>LO</sub> +4.01<sub>HI</sub>)
<b> CONF</b> 8.0+0.08 (1 THREAD 16 MB CACHE)
<b>  LLR</b> +2.96 (−2.94<sub>LO</sub> +2.94<sub>HI</sub> BND <i>for</i> −5.00<sub>LO</sub> +0.00<sub>HI</sub> ELO)
<b>GAMES</b> 15142 (3627<sub>W</sub><sup>24.0%</sup> 7938<sub>D</sub><sup>52.4%</sup> 3577<sub>L</sub><sup>23.6%</sup>)
<b>PENTA</b> 57<sub>+2</sub> 1813<sub>+1</sub> 3887<sub>+0</sub> 1751<sub>−1</sub> 63<sub>−2</sub>
</pre>