### PR TITLE
Tidy up some Neon code

### DIFF
--- a/src/nnue/simd.rs
+++ b/src/nnue/simd.rs
@@ -1283,10 +1283,7 @@ mod neon {
             let vec_b = vaddq_f32(vec.get_unchecked(1).inner(), vec.get_unchecked(3).inner());
             let vec = vaddq_f32(vec_a, vec_b);
 
-            // Transforms [a, b, c, d] into [a+b, c+d, a+b, c+d]
-            let pw_sum = vpaddq_f32(vec, vec);
-            // Sums [a+b, c+d] into a+b+c+d
-            vaddv_f32(vget_low_f32(pw_sum))
+            vaddvq_f32(vec)
         }
     }
 


### PR DESCRIPTION
First change doesn't change the generated assembly, but establishes a 1-to-1 correspondence between the intrinsics used and the generated instructions. Side note: Since the entire function compiles down to 3 instructions, I don't think the TODO on like 1112 is all that warranted.

The second change makes the compiler emit one (1) fewer instructions.