### PR TITLE
Use gravity formula for correction history updates.

### DIFF
--- a/src/history.rs
+++ b/src/history.rs
@@ -6,9 +6,9 @@ use crate::{
         types::Square,
     },
     historytable::{
-        CORRECTION_HISTORY_GRAIN, CORRECTION_HISTORY_MAX, cont_history_bonus, cont_history_malus,
-        main_history_bonus, main_history_malus, tactical_history_bonus, tactical_history_malus,
-        update_correction, update_history,
+        CORRECTION_HISTORY_MAX, cont_history_bonus, cont_history_malus, main_history_bonus,
+        main_history_malus, tactical_history_bonus, tactical_history_malus, update_correction,
+        update_history,
     },
     threadlocal::ThreadData,
     util::MAX_DEPTH,
@@ -208,7 +208,7 @@ impl ThreadData<'_> {
             + (white + black) * i64::from(self.info.conf.nonpawn_corrhist_weight)
             + cont * i64::from(self.info.conf.continuation_corrhist_weight);
 
-        (adjustment / 1024) as i32 / CORRECTION_HISTORY_GRAIN
+        (adjustment * 12 / 0x40000) as i32
     }
 }
 

--- a/src/history.rs
+++ b/src/history.rs
@@ -143,7 +143,7 @@ impl ThreadData<'_> {
         let height = self.board.height();
 
         let bonus = i32::clamp(
-            diff * (depth + 1),
+            diff * depth / 8,
             -CORRECTION_HISTORY_MAX / 4,
             CORRECTION_HISTORY_MAX / 4,
         );

--- a/src/historytable.rs
+++ b/src/historytable.rs
@@ -75,7 +75,6 @@ pub fn cont_history_malus(conf: &Config, depth: i32, index: usize) -> i32 {
 
 pub const MAX_HISTORY: i32 = i16::MAX as i32 / 2;
 pub const CORRECTION_HISTORY_SIZE: usize = 16_384;
-pub const CORRECTION_HISTORY_GRAIN: i32 = 256;
 pub const CORRECTION_HISTORY_MAX: i32 = 1024;
 
 pub fn update_history(val: &mut i16, delta: i32) {

--- a/src/historytable.rs
+++ b/src/historytable.rs
@@ -80,10 +80,13 @@ pub const CORRECTION_HISTORY_WEIGHT_SCALE: i32 = 256;
 pub const CORRECTION_HISTORY_MAX: i32 = CORRECTION_HISTORY_GRAIN * 32;
 
 pub fn update_history(val: &mut i16, delta: i32) {
+    gravity_update::<{ MAX_HISTORY as i32 }>(val, delta);
+}
+
+pub fn gravity_update<const MAX: i32>(val: &mut i16, delta: i32) {
     #![allow(clippy::cast_possible_truncation)]
-    const MAX_HISTORY: i32 = crate::historytable::MAX_HISTORY as i32;
     let curr = i32::from(*val);
-    *val += delta as i16 - (curr * delta.abs() / MAX_HISTORY) as i16;
+    *val += delta as i16 - (curr * delta.abs() / MAX) as i16;
 }
 
 #[repr(transparent)]

--- a/src/historytable.rs
+++ b/src/historytable.rs
@@ -76,14 +76,17 @@ pub fn cont_history_malus(conf: &Config, depth: i32, index: usize) -> i32 {
 pub const MAX_HISTORY: i16 = i16::MAX / 2;
 pub const CORRECTION_HISTORY_SIZE: usize = 16_384;
 pub const CORRECTION_HISTORY_GRAIN: i32 = 256;
-pub const CORRECTION_HISTORY_WEIGHT_SCALE: i32 = 256;
 pub const CORRECTION_HISTORY_MAX: i32 = CORRECTION_HISTORY_GRAIN * 32;
 
 pub fn update_history(val: &mut i16, delta: i32) {
     gravity_update::<{ MAX_HISTORY as i32 }>(val, delta);
 }
 
-pub fn gravity_update<const MAX: i32>(val: &mut i16, delta: i32) {
+pub fn update_correction(val: &mut i16, delta: i32) {
+    gravity_update::<{ CORRECTION_HISTORY_MAX }>(val, delta);
+}
+
+fn gravity_update<const MAX: i32>(val: &mut i16, delta: i32) {
     #![allow(clippy::cast_possible_truncation)]
     let curr = i32::from(*val);
     *val += delta as i16 - (curr * delta.abs() / MAX) as i16;

--- a/src/historytable.rs
+++ b/src/historytable.rs
@@ -73,17 +73,17 @@ pub fn cont_history_malus(conf: &Config, depth: i32, index: usize) -> i32 {
     }
 }
 
-pub const MAX_HISTORY: i16 = i16::MAX / 2;
+pub const MAX_HISTORY: i32 = i16::MAX as i32 / 2;
 pub const CORRECTION_HISTORY_SIZE: usize = 16_384;
 pub const CORRECTION_HISTORY_GRAIN: i32 = 256;
-pub const CORRECTION_HISTORY_MAX: i32 = CORRECTION_HISTORY_GRAIN * 32;
+pub const CORRECTION_HISTORY_MAX: i32 = 1024;
 
 pub fn update_history(val: &mut i16, delta: i32) {
-    gravity_update::<{ MAX_HISTORY as i32 }>(val, delta);
+    gravity_update::<MAX_HISTORY>(val, delta);
 }
 
 pub fn update_correction(val: &mut i16, delta: i32) {
-    gravity_update::<{ CORRECTION_HISTORY_MAX }>(val, delta);
+    gravity_update::<CORRECTION_HISTORY_MAX>(val, delta);
 }
 
 fn gravity_update<const MAX: i32>(val: &mut i16, delta: i32) {

--- a/src/movepicker.rs
+++ b/src/movepicker.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 
 pub const WINNING_CAPTURE_BONUS: i32 = 10_000_000;
-pub const MIN_WINNING_SEE_SCORE: i32 = WINNING_CAPTURE_BONUS - MAX_HISTORY as i32;
+pub const MIN_WINNING_SEE_SCORE: i32 = WINNING_CAPTURE_BONUS - MAX_HISTORY;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Stage {

--- a/src/search.rs
+++ b/src/search.rs
@@ -29,8 +29,8 @@ use crate::{
     },
     history::caphist_piece_type,
     historytable::{
-        CORRECTION_HISTORY_GRAIN, CORRECTION_HISTORY_MAX, cont1_history_bonus, cont1_history_malus,
-        cont2_history_bonus, cont2_history_malus, main_history_bonus, main_history_malus,
+        cont1_history_bonus, cont1_history_malus, cont2_history_bonus, cont2_history_malus,
+        main_history_bonus, main_history_malus,
     },
     lookups::HM_CLOCK_KEYS,
     movepicker::{MovePicker, Stage},
@@ -1582,12 +1582,7 @@ pub fn alpha_beta<NT: NodeType>(
             || flag == Bound::Lower && best_score <= static_eval
             || flag == Bound::Upper && best_score >= static_eval)
         {
-            let bonus = i32::clamp(
-                (best_score - static_eval) * depth * CORRECTION_HISTORY_GRAIN,
-                -CORRECTION_HISTORY_MAX / 4,
-                CORRECTION_HISTORY_MAX / 4,
-            );
-            t.update_correction_history(depth, bonus);
+            t.update_correction_history(depth, best_score - static_eval);
         }
         t.tt.store(
             key,

--- a/src/search.rs
+++ b/src/search.rs
@@ -29,8 +29,8 @@ use crate::{
     },
     history::caphist_piece_type,
     historytable::{
-        cont1_history_bonus, cont1_history_malus, cont2_history_bonus, cont2_history_malus,
-        main_history_bonus, main_history_malus,
+        CORRECTION_HISTORY_GRAIN, CORRECTION_HISTORY_MAX, cont1_history_bonus, cont1_history_malus,
+        cont2_history_bonus, cont2_history_malus, main_history_bonus, main_history_malus,
     },
     lookups::HM_CLOCK_KEYS,
     movepicker::{MovePicker, Stage},
@@ -1582,7 +1582,12 @@ pub fn alpha_beta<NT: NodeType>(
             || flag == Bound::Lower && best_score <= static_eval
             || flag == Bound::Upper && best_score >= static_eval)
         {
-            t.update_correction_history(depth, best_score - static_eval);
+            let bonus = i32::clamp(
+                (best_score - static_eval) * depth * CORRECTION_HISTORY_GRAIN,
+                -CORRECTION_HISTORY_MAX / 4,
+                CORRECTION_HISTORY_MAX / 4,
+            );
+            t.update_correction_history(depth, bonus);
         }
         t.tt.store(
             key,


### PR DESCRIPTION
<pre>
https://ob.expositor.dev/test/148/
<b>  ELO</b> +2.49 ± 1.83 (+0.66<sub>LO</sub> +4.32<sub>HI</sub>)
<b> CONF</b> 40.0+0.40 (1 THREAD 128 MB CACHE)
<b>  LLR</b> +2.95 (−2.94<sub>LO</sub> +2.94<sub>HI</sub> BOUNDS <i>for</i> +0.00<sub>LO</sub> +3.00<sub>HI</sub> ELO)
<b>GAMES</b> 32946 (7784<sub>W</sub><sup>23.6%</sup> 17614<sub>D</sub><sup>53.5%</sup> 7548<sub>L</sub><sup>22.9%</sup>)
<b>PENTA</b> 23<sub>+2</sub> 3916<sub>+1</sub> 8854<sub>+0</sub> 3634<sub>−1</sub> 46<sub>−2</sub>
</pre>