### PR TITLE
Scale corrhist updates by TT complexity.

### DIFF
--- a/src/history.rs
+++ b/src/history.rs
@@ -134,16 +134,20 @@ impl ThreadData<'_> {
     }
 
     /// Update the correction history for a pawn pattern.
-    pub fn update_correction_history(&mut self, depth: i32, diff: i32) {
-        #![allow(clippy::cast_possible_truncation)]
+    pub fn update_correction_history(&mut self, depth: i32, tt_complexity: i32, diff: i32) {
+        #![allow(clippy::cast_possible_truncation, clippy::cast_precision_loss)]
 
         use Colour::{Black, White};
 
         let us = self.board.turn();
         let height = self.board.height();
 
+        // wow! floating point in a chess engine!
+        let tt_complexity_factor =
+            ((1.0 + (tt_complexity as f32 + 1.0).log2() / 10.0) * 8.0) as i32;
+
         let bonus = i32::clamp(
-            diff * depth / 8,
+            diff * depth * tt_complexity_factor / 64,
             -CORRECTION_HISTORY_MAX / 4,
             CORRECTION_HISTORY_MAX / 4,
         );


### PR DESCRIPTION
<pre>
https://ob.expositor.dev/test/151/
<b>  ELO</b> +1.37 ± 1.09 (+0.27<sub>LO</sub> +2.46<sub>HI</sub>)
<b> CONF</b> 40.0+0.40 (1 THREAD 128 MB CACHE)
<b>  LLR</b> +2.98 (−2.94<sub>LO</sub> +2.94<sub>HI</sub> BOUNDS <i>for</i> +0.00<sub>LO</sub> +3.00<sub>HI</sub> ELO)
<b>GAMES</b> 93066 (21740<sub>W</sub><sup>23.4%</sup> 49952<sub>D</sub><sup>53.7%</sup> 21374<sub>L</sub><sup>23.0%</sup>)
<b>PENTA</b> 97<sub>+2</sub> 10973<sub>+1</sub> 24766<sub>+0</sub> 10593<sub>−1</sub> 104<sub>−2</sub>
</pre>