### PR TITLE
Boost history updates using best score instead of alpha.

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -1547,9 +1547,7 @@ pub fn alpha_beta<NT: NodeType>(
 
             // this heuristic is on the whole unmotivated, beyond mere empiricism.
             // perhaps it's really important to know which quiet moves are good in "bad" positions?
-            // note: if in check, static_eval will be VALUE_NONE, but this probably doesn't cause
-            // any issues.
-            let history_depth_boost = i32::from(static_eval <= alpha);
+            let history_depth_boost = i32::from(!in_check && static_eval <= best_score);
             update_quiet_history(
                 t,
                 quiets_tried.as_slice(),


### PR DESCRIPTION
<pre>
https://ob.expositor.dev/test/157/
<b>  ELO</b> +4.33 ± 2.67 (+1.67<sub>LO</sub> +7.00<sub>HI</sub>)
<b> CONF</b> 8.0+0.08 (1 THREAD 16 MB CACHE)
<b>  LLR</b> +2.99 (−2.94<sub>LO</sub> +2.94<sub>HI</sub> BOUNDS <i>for</i> +0.00<sub>LO</sub> +3.00<sub>HI</sub> ELO)
<b>GAMES</b> 17568 (4336<sub>W</sub><sup>24.7%</sup> 9115<sub>D</sub><sup>51.9%</sup> 4117<sub>L</sub><sup>23.4%</sup>)
<b>PENTA</b> 80<sub>+2</sub> 2179<sub>+1</sub> 4460<sub>+0</sub> 2010<sub>−1</sub> 55<sub>−2</sub>
</pre>