### PR TITLE
Reduce FT_SHIFT in preparation for NEON.

### DIFF
--- a/src/nnue/network/layers.rs
+++ b/src/nnue/network/layers.rs
@@ -1,5 +1,5 @@
 const AVX512CHUNK: usize = 512 / 32;
-const FT_SHIFT: u32 = 10;
+const FT_SHIFT: u32 = 9;
 #[allow(clippy::cast_precision_loss)]
 const L1_MUL: f32 = (1 << FT_SHIFT) as f32 / (QA as i32 * QA as i32 * QB as i32) as f32;
 


### PR DESCRIPTION
<pre>
https://ob.expositor.dev/test/162/
<b>  ELO</b> +4.59 ± 4.43 (+0.16<sub>LO</sub> +9.02<sub>HI</sub>)
<b> CONF</b> 8.0+0.08 (1 THREAD 16 MB CACHE)
<b>  LLR</b> +2.97 (−2.94<sub>LO</sub> +2.94<sub>HI</sub> BOUNDS <i>for</i> −5.00<sub>LO</sub> +0.00<sub>HI</sub> ELO)
<b>GAMES</b> 6288 (1552<sub>W</sub><sup>24.7%</sup> 3267<sub>D</sub><sup>52.0%</sup> 1469<sub>L</sub><sup>23.4%</sup>)
<b>PENTA</b> 30<sub>+2</sub> 766<sub>+1</sub> 1627<sub>+0</sub> 699<sub>−1</sub> 22<sub>−2</sub>
</pre>