### PR TITLE
Dynamic SEE threshold for probcut.

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -85,6 +85,7 @@ const DO_DEEPER_DEPTH_MARGIN: i32 = 14;
 const HISTORY_PRUNING_MARGIN: i32 = -4942;
 const QS_FUTILITY: i32 = 341;
 const SEE_STAT_SCORE_MUL: i32 = 20;
+const PROBCUT_SEE_SCALE: i32 = 256;
 
 const HISTORY_LMR_DIVISOR: i32 = 17205;
 const LMR_REFUTATION_MUL: i32 = 860;
@@ -1169,8 +1170,9 @@ pub fn alpha_beta<NT: NodeType>(
         // don't probcut if we have a tthit with value < pcbeta and depth >= depth - 3:
         && !matches!(tt_hit, Some(TTHit { value: v, depth: d, .. }) if v < pc_beta && d >= depth - 3)
     {
+        let see_threshold = (pc_beta - static_eval) * t.info.conf.probcut_see_scale / 256;
         let tt_move_if_capture = tt_move.filter(|m| t.board.is_tactical(*m));
-        let mut move_picker = MovePicker::new(tt_move_if_capture, None, 0);
+        let mut move_picker = MovePicker::new(tt_move_if_capture, None, see_threshold);
         move_picker.skip_quiets = true;
         while let Some(m) = move_picker.next(t) {
             t.tt.prefetch(t.board.key_after(m));

--- a/src/search/parameters.rs
+++ b/src/search/parameters.rs
@@ -22,11 +22,11 @@ use crate::{
         MAJOR_CORRHIST_WEIGHT, MINOR_CORRHIST_WEIGHT, NMP_DEPTH_MUL, NMP_IMPROVING_MARGIN,
         NMP_REDUCTION_EVAL_DIVISOR, NONPAWN_CORRHIST_WEIGHT, OPTIMISM_MATERIAL_BASE,
         OPTIMISM_OFFSET, PAWN_CORRHIST_WEIGHT, PROBCUT_IMPROVING_MARGIN, PROBCUT_MARGIN,
-        QS_FUTILITY, QS_SEE_BOUND, RAZORING_COEFF_0, RAZORING_COEFF_1, RFP_IMPROVING_MARGIN,
-        RFP_MARGIN, SEE_QUIET_MARGIN, SEE_STAT_SCORE_MUL, SEE_TACTICAL_MARGIN,
-        TACTICAL_HISTORY_BONUS_MAX, TACTICAL_HISTORY_BONUS_MUL, TACTICAL_HISTORY_BONUS_OFFSET,
-        TACTICAL_HISTORY_MALUS_MAX, TACTICAL_HISTORY_MALUS_MUL, TACTICAL_HISTORY_MALUS_OFFSET,
-        TRIPLE_EXTENSION_MARGIN,
+        PROBCUT_SEE_SCALE, QS_FUTILITY, QS_SEE_BOUND, RAZORING_COEFF_0, RAZORING_COEFF_1,
+        RFP_IMPROVING_MARGIN, RFP_MARGIN, SEE_QUIET_MARGIN, SEE_STAT_SCORE_MUL,
+        SEE_TACTICAL_MARGIN, TACTICAL_HISTORY_BONUS_MAX, TACTICAL_HISTORY_BONUS_MUL,
+        TACTICAL_HISTORY_BONUS_OFFSET, TACTICAL_HISTORY_MALUS_MAX, TACTICAL_HISTORY_MALUS_MUL,
+        TACTICAL_HISTORY_MALUS_OFFSET, TRIPLE_EXTENSION_MARGIN,
     },
     timemgmt::{
         DEFAULT_MOVES_TO_GO, FAIL_LOW_TM_BONUS, HARD_WINDOW_FRAC, INCREMENT_FRAC,
@@ -124,6 +124,7 @@ pub struct Config {
     pub optimism_offset: i32,
     pub optimism_mat_base: i32,
     pub eval_policy_update_max: i32,
+    pub probcut_see_scale: i32,
 }
 
 impl Config {
@@ -216,6 +217,7 @@ impl Config {
             optimism_offset: OPTIMISM_OFFSET,
             optimism_mat_base: OPTIMISM_MATERIAL_BASE,
             eval_policy_update_max: EVAL_POLICY_UPDATE_MAX,
+            probcut_see_scale: PROBCUT_SEE_SCALE,
         }
     }
 }
@@ -346,7 +348,8 @@ impl Config {
             HINDSIGHT_RED_EVAL = [self.hindsight_red_eval],
             OPTIMISM_OFFSET = [self.optimism_offset],
             OPTIMISM_MATERIAL_BASE = [self.optimism_mat_base],
-            EVAL_POLICY_UPDATE_MAX = [self.eval_policy_update_max]
+            EVAL_POLICY_UPDATE_MAX = [self.eval_policy_update_max],
+            PROBCUT_SEE_SCALE = [self.probcut_see_scale]
         ]
     }
 
@@ -447,7 +450,8 @@ impl Config {
             HINDSIGHT_RED_EVAL = [self.hindsight_red_eval, -4096, 4096, 8],
             OPTIMISM_OFFSET = [self.optimism_offset, -4096, 4096, 16],
             OPTIMISM_MATERIAL_BASE = [self.optimism_mat_base, 1, 8192, 256],
-            EVAL_POLICY_UPDATE_MAX = [self.eval_policy_update_max, 1, 4096, 8]
+            EVAL_POLICY_UPDATE_MAX = [self.eval_policy_update_max, 1, 4096, 8],
+            PROBCUT_SEE_SCALE = [self.probcut_see_scale, 1, 1024, 16]
         ]
     }
 


### PR DESCRIPTION
<pre>
https://ob.expositor.dev/test/169/
<b>  LLR</b> +2.95 (−2.94<sub>LO</sub> +2.94<sub>HI</sub> BOUNDS <i>for</i> +0.00<sub>LO</sub> +3.00<sub>HI</sub> ELO)
<b>  ELO</b> +1.70 ± 1.37 (+0.33<sub>LO</sub> +3.07<sub>HI</sub>)
<b> CONF</b> 8.0+0.08 (1 THREAD 16 MB CACHE)
<b>GAMES</b> 67570 (16521<sub>W</sub><sup>24.5%</sup> 34859<sub>D</sub><sup>51.6%</sup> 16190<sub>L</sub><sup>24.0%</sup>)
<b>PENTA</b> 277<sub>+2</sub> 8280<sub>+1</sub> 17018<sub>+0</sub> 7917<sub>−1</sub> 293<sub>−2</sub>
</pre>