### PR TITLE
Boost history for NMP refutations.

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -1552,9 +1552,12 @@ pub fn alpha_beta<NT: NodeType>(
 
             // this heuristic is on the whole unmotivated, beyond mere empiricism.
             // perhaps it's really important to know which quiet moves are good in "bad" positions?
-            let boost = i32::from(!in_check && static_eval <= best_score);
+            let low = i32::from(!in_check && static_eval <= best_score);
 
-            update_quiet_history(t, &quiets_tried, best_move, depth + boost);
+            // boost history for nmp refutations
+            let nmp = i32::from(!NT::ROOT && t.ss[height - 1].searching.is_none());
+
+            update_quiet_history(t, &quiets_tried, best_move, depth + low + nmp);
         }
 
         // we unconditionally update the tactical history table


### PR DESCRIPTION
<pre>
https://ob.expositor.dev/test/194/
<b>  LLR</b> +3.00 (−2.94<sub>LO</sub> +2.94<sub>HI</sub> BOUNDS <i>for</i> +0.00<sub>LO</sub> +3.00<sub>HI</sub> ELO)
<b>  ELO</b> +2.32 ± 1.76 (+0.56<sub>LO</sub> +4.08<sub>HI</sub>)
<b> CONF</b> 8.0+0.08 (1 THREAD 16 MB CACHE)
<b>GAMES</b> 41136 (10129<sub>W</sub><sup>24.6%</sup> 21153<sub>D</sub><sup>51.4%</sup> 9854<sub>L</sub><sup>24.0%</sup>)
<b>PENTA</b> 207<sub>+2</sub> 4996<sub>+1</sub> 10395<sub>+0</sub> 4805<sub>−1</sub> 165<sub>−2</sub>
</pre>