### PR TITLE
Don't cut when TT value is decisive.

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -831,9 +831,8 @@ pub fn alpha_beta<NT: NodeType>(
                     || (hit.bound == Bound::Upper && hit.value <= alpha))
             {
                 // add to the history of a quiet move that fails high here.
-                if let Some(mov) = hit.mov
+                if let Some(mov) = tt_move
                     && hit.value >= beta
-                    && tt_move_legal
                     && !t.board.is_tactical(mov)
                 {
                     let from = mov.from();
@@ -845,7 +844,9 @@ pub fn alpha_beta<NT: NodeType>(
 
                 // only cut at high depth if the tt move is legal,
                 // or if it's absent and we're failing low.
-                if depth < 8 || tt_move_legal || hit.mov.is_none() && hit.bound == Bound::Upper {
+                if (tt_move_legal || hit.mov.is_none() && hit.bound == Bound::Upper)
+                    && !is_decisive(hit.value)
+                {
                     return hit.value;
                 }
             }


### PR DESCRIPTION
<pre>
https://ob.expositor.dev/test/219/
<b>  LLR</b> +3.16 (−2.94<sub>LO</sub> +2.94<sub>HI</sub> BOUNDS <i>for</i> −3.00<sub>LO</sub> +0.00<sub>HI</sub> ELO)
<b>  ELO</b> +2.40 ± 2.46 (−0.06<sub>LO</sub> +4.86<sub>HI</sub>)
<b> CONF</b> 8.0+0.08 (1 THREAD 16 MB CACHE)
<b>GAMES</b> 20824 (5049<sub>W</sub><sup>24.2%</sup> 10870<sub>D</sub><sup>52.2%</sup> 4905<sub>L</sub><sup>23.6%</sup>)
<b>PENTA</b> 82<sub>+2</sub> 2574<sub>+1</sub> 5242<sub>+0</sub> 2434<sub>−1</sub> 80<sub>−2</sub>
</pre>