### PR TITLE
Restrict time usage to 95% of clock.

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -36,6 +36,7 @@ use crate::{
     tablebases::{self, probe::WDL},
     threadlocal::ThreadData,
     threadpool::{self, ScopeExt},
+    timemgmt::SearchLimit,
     transpositiontable::{Bound, TTHit},
     uci,
     util::{INFINITY, MAX_DEPTH, VALUE_NONE},
@@ -263,6 +264,7 @@ pub fn search_position(
         for (t, w) in rest.iter_mut().zip(rest_workers) {
             handles.push(s.spawn_into(
                 || {
+                    assert!(matches!(t.info.clock.limit(), SearchLimit::Infinite));
                     iterative_deepening::<HelperThread>(t);
                 },
                 w,
@@ -434,7 +436,8 @@ fn iterative_deepening<ThTy: SmpThreadType>(t: &mut ThreadData) {
 
             if let Some(margin) = t.info.clock.check_for_forced_move(t.depth) {
                 let saved_seldepth = t.info.seldepth;
-                let forced = is_forced(margin, t, best_move, score, (t.depth - 1) / 2);
+                let forced =
+                    is_forced(margin, t, best_move, score, i32::min(12, (t.depth - 1) / 2));
                 t.info.seldepth = saved_seldepth;
 
                 if forced {

--- a/src/timemgmt.rs
+++ b/src/timemgmt.rs
@@ -96,33 +96,33 @@ impl SearchLimit {
         our_inc: u64,
         conf: &Config,
     ) -> (u64, u64, u64) {
-        // The absolute maximum time we could spend without losing on the clock:
-        let absolute_maximum = our_clock.saturating_sub(MOVE_OVERHEAD);
+        // The very highest amount of time we are
+        // willing to search in a position, ever.
+        let max_time = (our_clock * 95 / 100).saturating_sub(MOVE_OVERHEAD);
 
         // The maximum time we can spend searching before forcibly stopping:
-        let hard_time_window =
-            (our_clock * u64::from(conf.hard_window_frac) / 100).min(absolute_maximum);
+        let hard_time_window = (our_clock * u64::from(conf.hard_window_frac) / 100).min(max_time);
 
         // If we have a moves to go, we can use that to compute a time window.
         if let Some(moves_to_go) = moves_to_go {
             // Use more time if we have fewer moves to go, but not more than default_moves_to_go.
             let divisor = moves_to_go.clamp(2, u64::from(conf.default_moves_to_go));
             let computed_time_window = our_clock / divisor;
-            let optimal_time_window = computed_time_window.min(absolute_maximum)
-                * u64::from(conf.optimal_window_frac)
-                / 100;
-            return (optimal_time_window, hard_time_window, absolute_maximum);
+            let optimal_time_window =
+                computed_time_window.min(max_time) * u64::from(conf.optimal_window_frac) / 100;
+            return (optimal_time_window, hard_time_window, max_time);
         }
 
         // Otherwise, we use default_moves_to_go.
         let computed_time_window = our_clock / u64::from(conf.default_moves_to_go)
             + our_inc * u64::from(conf.increment_frac) / 100
             - MOVE_OVERHEAD;
-        let optimal_time_window = (computed_time_window.min(absolute_maximum)
-            * u64::from(conf.optimal_window_frac)
-            / 100)
-            .min(hard_time_window);
-        (optimal_time_window, hard_time_window, absolute_maximum)
+
+        let optimal_time_window =
+            (computed_time_window.min(max_time) * u64::from(conf.optimal_window_frac) / 100)
+                .min(hard_time_window);
+
+        (optimal_time_window, hard_time_window, max_time)
     }
 
     #[cfg(test)]


### PR DESCRIPTION
STC:
<pre>
https://ob.expositor.dev/test/236/
<b>  LLR</b> +2.95 (−2.94<sub>LO</sub> +2.94<sub>HI</sub> BOUNDS <i>for</i> −5.00<sub>LO</sub> +0.00<sub>HI</sub> ELO)
<b>  ELO</b> −0.35 ± 1.68 (−2.03<sub>LO</sub> +1.33<sub>HI</sub>)
<b> CONF</b> 8.0+0.08 (1 THREAD 16 MB CACHE)
<b>GAMES</b> 39768 (9674<sub>W</sub><sup>24.3%</sup> 20380<sub>D</sub><sup>51.2%</sup> 9714<sub>L</sub><sup>24.4%</sup>)
<b>PENTA</b> 142<sub>+2</sub> 4259<sub>+1</sub> 11031<sub>+0</sub> 4321<sub>−1</sub> 131<sub>−2</sub>
</pre>
LTC:
<pre>
https://ob.expositor.dev/test/237/
<b>  LLR</b> +2.95 (−2.94<sub>LO</sub> +2.94<sub>HI</sub> BOUNDS <i>for</i> −5.00<sub>LO</sub> +0.00<sub>HI</sub> ELO)
<b>  ELO</b> +2.20 ± 3.11 (−0.91<sub>LO</sub> +5.31<sub>HI</sub>)
<b> CONF</b> 40.0+0.40 (1 THREAD 128 MB CACHE)
<b>GAMES</b> 9628 (2274<sub>W</sub><sup>23.6%</sup> 5141<sub>D</sub><sup>53.4%</sup> 2213<sub>L</sub><sup>23.0%</sup>)
<b>PENTA</b> 6<sub>+2</sub> 977<sub>+1</sub> 2907<sub>+0</sub> 920<sub>−1</sub> 4<sub>−2</sub>
</pre>
STC SMP:
<pre>
https://ob.expositor.dev/test/238/
<b>  LLR</b> +3.00 (−2.94<sub>LO</sub> +2.94<sub>HI</sub> BOUNDS <i>for</i> −5.00<sub>LO</sub> +0.00<sub>HI</sub> ELO)
<b>  ELO</b> +4.94 ± 5.20 (−0.26<sub>LO</sub> +10.14<sub>HI</sub>)
<b> CONF</b> 8.0+0.08 (4 THREADS 64 MB CACHE)
<b>GAMES</b> 7106 (2122<sub>W</sub><sup>29.9%</sup> 2963<sub>D</sub><sup>41.7%</sup> 2021<sub>L</sub><sup>28.4%</sup>)
<b>PENTA</b> 190<sub>+2</sub> 808<sub>+1</sub> 1610<sub>+0</sub> 803<sub>−1</sub> 142<sub>−2</sub>
</pre>