### PR TITLE
Prevent false mate scores bubbling up from quiescence.

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -674,7 +674,9 @@ pub fn quiescence<NT: NodeType>(
         };
         t.board.make_move(m, &mut t.nnue);
         // move found, we can start skipping quiets again:
-        move_picker.skip_quiets = true;
+        if best_score > -MINIMUM_TB_WIN_SCORE {
+            move_picker.skip_quiets = true;
+        }
         t.info.nodes.increment();
         moves_made += 1;
 


### PR DESCRIPTION
<pre>
https://ob.expositor.dev/test/266/
<b>  LLR</b> +2.98 (−2.94<sub>LO</sub> +2.94<sub>HI</sub> BOUNDS <i>for</i> −5.00<sub>LO</sub> +0.00<sub>HI</sub> ELO)
<b>  ELO</b> −0.37 ± 1.76 (−2.13<sub>LO</sub> +1.39<sub>HI</sub>)
<b> CONF</b> 8.0+0.08 (1 THREAD 16 MB CACHE)
<b>GAMES</b> 40292 (9694<sub>W</sub><sup>24.1%</sup> 20861<sub>D</sub><sup>51.8%</sup> 9737<sub>L</sub><sup>24.2%</sup>)
<b>PENTA</b> 143<sub>+2</sub> 4800<sub>+1</sub> 10236<sub>+0</sub> 4805<sub>−1</sub> 162<sub>−2</sub>
</pre>