### PR TITLE
Increase the robustness of Probcut.

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -1215,7 +1215,9 @@ pub fn alpha_beta<NT: NodeType>(
                     t.ss[height].ttpv,
                 );
 
-                return value - (pc_beta - beta);
+                if !is_decisive(value) {
+                    return value - (pc_beta - beta);
+                }
             }
         }
 


### PR DESCRIPTION
<pre>
https://ob.expositor.dev/test/277/
<b>  LLR</b> +3.06 (−2.94<sub>LO</sub> +2.94<sub>HI</sub> BOUNDS <i>for</i> −5.00<sub>LO</sub> +0.00<sub>HI</sub> ELO)
<b>  ELO</b> −0.14 ± 1.94 (−2.08<sub>LO</sub> +1.81<sub>HI</sub>)
<b> CONF</b> 8.0+0.08 (1 THREAD 16 MB CACHE)
<b>GAMES</b> 33036 (7998<sub>W</sub><sup>24.2%</sup> 17027<sub>D</sub><sup>51.5%</sup> 8011<sub>L</sub><sup>24.2%</sup>)
<b>PENTA</b> 133<sub>+2</sub> 3916<sub>+1</sub> 8391<sub>+0</sub> 3961<sub>−1</sub> 117<sub>−2</sub>
</pre>