### PR TITLE
Fail-Soft Multicut.

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -1373,10 +1373,6 @@ pub fn alpha_beta<NT: NodeType>(
 
             if value == VALUE_NONE {
                 extension = 1; // extend if there's only one legal move.
-            } else if value >= beta && !is_decisive(value) {
-                // multi-cut: if a move other than the best one beats beta,
-                // then we can cut with relatively high confidence.
-                return value;
             } else if value < r_beta {
                 if !NT::PV
                     && t.ss[t.board.height()].dextensions <= 12
@@ -1388,6 +1384,10 @@ pub fn alpha_beta<NT: NodeType>(
                     // normal singular extension
                     extension = 1;
                 }
+            } else if value >= beta && !is_decisive(value) {
+                // multi-cut: if a move other than the best one beats beta,
+                // then we can cut with relatively high confidence.
+                return value;
             } else if cut_node {
                 // produce a strong negative extension if we didn't fail low on a cut-node.
                 extension = -2;


### PR DESCRIPTION
<pre>
https://ob.expositor.dev/test/289/
<b>  LLR</b> +3.07 (−2.94<sub>LO</sub> +2.94<sub>HI</sub> BOUNDS <i>for</i> +0.00<sub>LO</sub> +3.00<sub>HI</sub> ELO)
<b>  ELO</b> +1.50 ± 1.19 (+0.31<sub>LO</sub> +2.69<sub>HI</sub>)
<b> CONF</b> 8.0+0.08 (1 THREAD 16 MB CACHE)
<b>GAMES</b> 88256 (21384<sub>W</sub><sup>24.2%</sup> 45869<sub>D</sub><sup>52.0%</sup> 21003<sub>L</sub><sup>23.8%</sup>)
<b>PENTA</b> 317<sub>+2</sub> 10739<sub>+1</sub> 22382<sub>+0</sub> 10388<sub>−1</sub> 302<sub>−2</sub>
</pre>