### PR TITLE
Remove low-depth singular extensions.

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -1395,13 +1395,6 @@ pub fn alpha_beta<NT: NodeType>(
                 // the tt_value >= beta condition is a sort of "light multi-cut"
                 // the tt_value <= alpha condition is from Weiss (https://github.com/TerjeKir/weiss/compare/2a7b4ed0...effa8349/).
                 extension = -1;
-            } else if depth < 8
-                && !in_check
-                && static_eval < alpha - 25
-                && tte.bound == Bound::Lower
-            {
-                // low-depth singular extension.
-                extension = 1;
             } else {
                 // no extension.
                 extension = 0;


### PR DESCRIPTION
<pre>
https://ob.expositor.dev/test/291/
<b>  LLR</b> +3.00 (−2.94<sub>LO</sub> +2.94<sub>HI</sub> BOUNDS <i>for</i> −5.00<sub>LO</sub> +0.00<sub>HI</sub> ELO)
<b>  ELO</b> +2.89 ± 3.70 (−0.81<sub>LO</sub> +6.58<sub>HI</sub>)
<b> CONF</b> 8.0+0.08 (1 THREAD 16 MB CACHE)
<b>GAMES</b> 8910 (2141<sub>W</sub><sup>24.0%</sup> 4702<sub>D</sub><sup>52.8%</sup> 2067<sub>L</sub><sup>23.2%</sup>)
<b>PENTA</b> 27<sub>+2</sub> 1096<sub>+1</sub> 2285<sub>+0</sub> 1018<sub>−1</sub> 29<sub>−2</sub>
</pre>