### PR TITLE
Avoid singext at lower depths, TT-PV nodes.

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -1245,10 +1245,6 @@ pub fn alpha_beta<NT: NodeType>(
     let mut quiets_tried = ArrayVec::<_, MAX_POSITION_MOVES>::new();
     let mut tacticals_tried = ArrayVec::<_, MAX_POSITION_MOVES>::new();
 
-    let maybe_singular = depth >= 5
-        && excluded.is_none()
-        && tt_hit.is_some_and(|tte| tte.depth >= depth - 3 && tte.bound.is_lower());
-
     while let Some(m) = move_picker.next(t) {
         if excluded == Some(m) {
             continue;
@@ -1335,8 +1331,14 @@ pub fn alpha_beta<NT: NodeType>(
         let extension;
         if NT::ROOT {
             extension = 0;
-        } else if maybe_singular && Some(m) == tt_move {
-            let tte = tt_hit.unwrap();
+        } else if Some(m) == tt_move
+            && excluded.is_none()
+            && depth >= 6 + i32::from(t.ss[height].ttpv)
+            && let Some(tte) = tt_hit
+            && tte.value != VALUE_NONE
+            && tte.bound.is_lower()
+            && tte.depth >= depth - 3
+        {
             let r_beta = singularity_margin(tte.value, depth);
             let r_depth = (depth - 1) / 2;
 


### PR DESCRIPTION
<pre>
https://ob.expositor.dev/test/299/
<b>  LLR</b> +2.95 (−2.94<sub>LO</sub> +2.94<sub>HI</sub> BOUNDS <i>for</i> +0.00<sub>LO</sub> +3.00<sub>HI</sub> ELO)
<b>  ELO</b> +0.94 ± 0.57 (+0.37<sub>LO</sub> +1.51<sub>HI</sub>)
<b> CONF</b> 8.0+0.08 (1 THREAD 16 MB CACHE)
<b>GAMES</b> 376896 (91102<sub>W</sub><sup>24.2%</sup> 195712<sub>D</sub><sup>51.9%</sup> 90082<sub>L</sub><sup>23.9%</sup>)
<b>PENTA</b> 1573<sub>+2</sub> 45113<sub>+1</sub> 95783<sub>+0</sub> 44719<sub>−1</sub> 1260<sub>−2</sub>
</pre>