### PR TITLE
Start all threads at depth 1.

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -349,9 +349,8 @@ fn iterative_deepening<ThTy: SmpThreadType>(t: &mut ThreadData) {
     );
     let mut pv = PVariation::default();
     let max_depth = dyn_max_depth(t);
-    let starting_depth = 1 + t.thread_id % 10;
     let mut average_value = VALUE_NONE;
-    'deepening: for iteration in starting_depth..=max_depth {
+    'deepening: for iteration in 1..=max_depth {
         t.iteration = iteration;
         t.depth = i32::try_from(iteration).unwrap();
         t.optimism = [0; 2];


### PR DESCRIPTION
<pre>
https://ob.expositor.dev/test/319/
<b>  LLR</b> +2.98 (−2.94<sub>LO</sub> +2.94<sub>HI</sub> BOUNDS <i>for</i> −3.00<sub>LO</sub> +0.00<sub>HI</sub> ELO)
<b>  ELO</b> +0.50 ± 1.55 (−1.05<sub>LO</sub> +2.05<sub>HI</sub>)
<b> CONF</b> 8+0.08 SEC (4 THREADS 16 MB CACHE)
<b>GAMES</b> 47806 (11254<sub>W</sub><sup>23.5%</sup> 25367<sub>D</sub><sup>53.1%</sup> 11185<sub>L</sub><sup>23.4%</sup>)
<b>PENTA</b> 83<sub>+2</sub> 5615<sub>+1</sub> 12571<sub>+0</sub> 5556<sub>−1</sub> 78<sub>−2</sub>
</pre>
<pre>
https://ob.expositor.dev/test/318/
<b>  LLR</b> +2.98 (−2.94<sub>LO</sub> +2.94<sub>HI</sub> BOUNDS <i>for</i> −3.00<sub>LO</sub> +0.00<sub>HI</sub> ELO)
<b>  ELO</b> −0.01 ± 1.20 (−1.21<sub>LO</sub> +1.19<sub>HI</sub>)
<b> CONF</b> 4+0.04 SEC (8 THREADS 16 MB CACHE)
<b>GAMES</b> 80956 (19135<sub>W</sub><sup>23.6%</sup> 42684<sub>D</sub><sup>52.7%</sup> 19137<sub>L</sub><sup>23.6%</sup>)
<b>PENTA</b> 174<sub>+2</sub> 9463<sub>+1</sub> 21196<sub>+0</sub> 9477<sub>−1</sub> 168<sub>−2</sub>
</pre>