### PR TITLE
Use move score in futility margin.

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -1303,7 +1303,9 @@ pub fn alpha_beta<NT: NodeType>(
 
             // futility pruning
             // if the static eval is too low, we start skipping moves.
-            let fp_margin = lmr_depth * t.info.conf.futility_coeff_1 + t.info.conf.futility_coeff_0;
+            let fp_margin = lmr_depth * t.info.conf.futility_coeff_1
+                + t.info.conf.futility_coeff_0
+                + stat_score / 128;
             if is_quiet && lmr_depth < 6 && static_eval + fp_margin <= alpha {
                 move_picker.skip_quiets = true;
             }


### PR DESCRIPTION
<pre>
https://ob.expositor.dev/test/363/
<b>  LLR</b> +3.00 (−2.94<sub>LO</sub> +2.94<sub>HI</sub> BOUNDS <i>for</i> +0.00<sub>LO</sub> +3.00<sub>HI</sub> ELO)
<b>  ELO</b> +1.12 ± 0.82 (+0.29<sub>LO</sub> +1.94<sub>HI</sub>)
<b> CONF</b> 8+0.08 SEC (1 THREAD 16 MB CACHE)
<b>GAMES</b> 180744 (44209<sub>W</sub><sup>24.5%</sup> 92907<sub>D</sub><sup>51.4%</sup> 43628<sub>L</sub><sup>24.1%</sup>)
<b>PENTA</b> 626<sub>+2</sub> 21768<sub>+1</sub> 46153<sub>+0</sub> 21211<sub>−1</sub> 614<sub>−2</sub>
</pre>