### PR TITLE
Guard extensions via root-depth.

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -358,10 +358,10 @@ fn iterative_deepening<ThTy: SmpThreadType>(t: &mut ThreadData) {
     let mut average_value = VALUE_NONE;
     'deepening: for iteration in 1..=max_depth {
         t.iteration = iteration;
-        t.depth = i32::try_from(iteration).unwrap();
+        t.root_depth = i32::try_from(iteration).unwrap();
         t.optimism = [0; 2];
 
-        let min_depth = (t.depth / 2).max(1);
+        let min_depth = (t.root_depth / 2).max(1);
 
         let mut alpha = -INFINITY;
         let mut beta = INFINITY;
@@ -369,7 +369,7 @@ fn iterative_deepening<ThTy: SmpThreadType>(t: &mut ThreadData) {
         let mut delta = t.info.conf.delta_initial;
         let mut reduction = 0;
 
-        if t.depth > 1 {
+        if t.root_depth > 1 {
             let us = t.board.turn();
             let offset = t.info.conf.optimism_offset;
             t.optimism[us] = 128 * average_value / (average_value.abs() + offset);
@@ -383,7 +383,7 @@ fn iterative_deepening<ThTy: SmpThreadType>(t: &mut ThreadData) {
 
         // aspiration loop:
         loop {
-            let root_draft = (t.depth - reduction).max(min_depth);
+            let root_draft = (t.root_depth - reduction).max(min_depth);
             pv.score = alpha_beta::<Root>(&mut pv, t, root_draft, alpha, beta, false);
             if t.info.check_up() {
                 break 'deepening; // we've been told to stop searching.
@@ -395,7 +395,7 @@ fn iterative_deepening<ThTy: SmpThreadType>(t: &mut ThreadData) {
                     readout_info(t, &t.info, Bound::Upper, t.info.nodes.get_global(), false);
                     t.info
                         .clock
-                        .report_aspiration_fail(t.depth, Bound::Upper, &t.info.conf);
+                        .report_aspiration_fail(t.root_depth, Bound::Upper, &t.info.conf);
                 }
                 beta = i32::midpoint(alpha, beta);
                 alpha = (pv.score - delta).max(-INFINITY);
@@ -409,13 +409,13 @@ fn iterative_deepening<ThTy: SmpThreadType>(t: &mut ThreadData) {
                     readout_info(t, &t.info, Bound::Lower, t.info.nodes.get_global(), false);
                     t.info
                         .clock
-                        .report_aspiration_fail(t.depth, Bound::Lower, &t.info.conf);
+                        .report_aspiration_fail(t.root_depth, Bound::Lower, &t.info.conf);
                 }
                 beta = (pv.score + delta).min(INFINITY);
                 reduction += 1;
                 // decrement depth:
                 if !is_decisive(pv.score) {
-                    t.depth = (t.depth - 1).max(min_depth);
+                    t.root_depth = (t.root_depth - 1).max(min_depth);
                 }
             } else {
                 t.update_best_line(&pv);
@@ -444,19 +444,24 @@ fn iterative_deepening<ThTy: SmpThreadType>(t: &mut ThreadData) {
         if ThTy::MAIN_THREAD {
             readout_info(t, &t.info, Bound::Exact, t.info.nodes.get_global(), false);
 
-            if let Some(margin) = t.info.clock.check_for_forced_move(t.depth) {
+            if let Some(margin) = t.info.clock.check_for_forced_move(t.root_depth) {
                 let saved_seldepth = t.info.seldepth;
-                let forced =
-                    is_forced(margin, t, best_move, score, i32::min(12, (t.depth - 1) / 2));
+                let forced = is_forced(
+                    margin,
+                    t,
+                    best_move,
+                    score,
+                    i32::min(12, (t.root_depth - 1) / 2),
+                );
                 t.info.seldepth = saved_seldepth;
 
                 if forced {
-                    t.info.clock.report_forced_move(t.depth, &t.info.conf);
+                    t.info.clock.report_forced_move(t.root_depth, &t.info.conf);
                 }
             }
 
-            if t.depth > TIME_MANAGER_UPDATE_MIN_DEPTH {
-                let bm_frac = if t.depth > 8 {
+            if t.root_depth > TIME_MANAGER_UPDATE_MIN_DEPTH {
+                let bm_frac = if t.root_depth > 8 {
                     let best_move_subtree_size =
                         t.info.root_move_nodes[best_move.from()][best_move.history_to_square()];
                     let tree_size = t.info.nodes.get_local();
@@ -466,7 +471,7 @@ fn iterative_deepening<ThTy: SmpThreadType>(t: &mut ThreadData) {
                     None
                 };
                 t.info.clock.report_completed_depth(
-                    t.depth,
+                    t.root_depth,
                     pv.score,
                     pv.moves[0],
                     bm_frac,
@@ -1341,6 +1346,9 @@ pub fn alpha_beta<NT: NodeType>(
         t.info.nodes.increment();
         moves_made += 1;
 
+        #[expect(clippy::cast_sign_loss)]
+        let root_depth = t.root_depth as usize;
+
         let extension;
         if NT::ROOT {
             extension = 0;
@@ -1351,6 +1359,7 @@ pub fn alpha_beta<NT: NodeType>(
             && tte.value != VALUE_NONE
             && tte.bound.is_lower()
             && tte.depth >= depth - 3
+            && height < root_depth * 2
         {
             let r_beta = singularity_margin(tte.value, depth);
             let r_depth = (depth - 1) / 2;

--- a/src/threadlocal.rs
+++ b/src/threadlocal.rs
@@ -48,7 +48,7 @@ pub struct ThreadData<'a> {
     /// the highest finished ID iteration
     pub completed: usize,
     /// the draft we're actually kicking off searches at
-    pub depth: i32,
+    pub root_depth: i32,
 
     pub stm_at_root: Colour,
     pub optimism: [i32; 2],
@@ -96,7 +96,7 @@ impl<'a> ThreadData<'a> {
             pvs: [Self::ARRAY_REPEAT_VALUE; MAX_DEPTH],
             iteration: 0,
             completed: 0,
-            depth: 0,
+            root_depth: 0,
             stm_at_root: board.turn(),
             optimism: [0; 2],
             tt,
@@ -147,14 +147,14 @@ impl<'a> ThreadData<'a> {
         self.minor_corrhist.clear();
         self.continuation_corrhist.clear();
         self.killer_move_table.fill(None);
-        self.depth = 0;
+        self.root_depth = 0;
         self.completed = 0;
         self.pvs.fill(Self::ARRAY_REPEAT_VALUE);
     }
 
     pub fn set_up_for_search(&mut self) {
         self.killer_move_table.fill(None);
-        self.depth = 0;
+        self.root_depth = 0;
         self.completed = 0;
         self.pvs.fill(Self::ARRAY_REPEAT_VALUE);
         self.nnue.reinit_from(&self.board, self.nnue_params);


### PR DESCRIPTION
<pre>
https://ob.expositor.dev/test/367/
<b>  LLR</b> +2.95 (−2.94<sub>LO</sub> +2.94<sub>HI</sub> BOUNDS <i>for</i> −3.00<sub>LO</sub> +0.00<sub>HI</sub> ELO)
<b>  ELO</b> +0.30 ± 1.36 (−1.06<sub>LO</sub> +1.66<sub>HI</sub>)
<b> CONF</b> 40+0.4 SEC (1 THREAD 128 MB CACHE)
<b>GAMES</b> 55532 (12949<sub>W</sub><sup>23.3%</sup> 29682<sub>D</sub><sup>53.5%</sup> 12901<sub>L</sub><sup>23.2%</sup>)
<b>PENTA</b> 35<sub>+2</sub> 6021<sub>+1</sub> 15704<sub>+0</sub> 5969<sub>−1</sub> 37<sub>−2</sub>
</pre>