### PR TITLE
Correctly record reduction for full-depth ZWS.

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -1473,12 +1473,15 @@ pub fn alpha_beta<NT: NodeType>(
                 // depending on the value that the reduced search kicked out,
                 // we might want to do a deeper search, or a shallower search.
                 new_depth += i32::from(do_deeper_search) - i32::from(do_shallower_search);
+                t.ss[height].reduction =
+                    1024 * (1 + i32::from(do_shallower_search) - i32::from(do_deeper_search));
                 // check if we're actually going to do a deeper search than before
                 // (no point if the re-search is the same as the normal one lol)
                 if new_depth - 1 > reduced_depth {
                     score =
                         -alpha_beta::<OffPV>(l_pv, t, new_depth - 1, -alpha - 1, -alpha, !cut_node);
                 }
+                t.ss[height].reduction = 1024;
 
                 if is_quiet && (score <= alpha || score >= beta) {
                     t.update_cont_hist_single(hist_to, moved, new_depth, height, score > alpha);


### PR DESCRIPTION
<pre>
https://ob.expositor.dev/test/374/
<b>  LLR</b> +3.10 (−2.94<sub>LO</sub> +2.94<sub>HI</sub> BOUNDS <i>for</i> −3.00<sub>LO</sub> +0.00<sub>HI</sub> ELO)
<b>  ELO</b> +1.62 ± 2.13 (−0.52<sub>LO</sub> +3.75<sub>HI</sub>)
<b> CONF</b> 8+0.08 SEC (1 THREAD 16 MB CACHE)
<b>GAMES</b> 26854 (6599<sub>W</sub><sup>24.6%</sup> 13781<sub>D</sub><sup>51.3%</sup> 6474<sub>L</sub><sup>24.1%</sup>)
<b>PENTA</b> 89<sub>+2</sub> 3256<sub>+1</sub> 6853<sub>+0</sub> 3149<sub>−1</sub> 80<sub>−2</sub>
</pre>