### PR TITLE
Fail-firm quiescence search.

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -723,6 +723,10 @@ pub fn quiescence<NT: NodeType>(
         return mated_in(height);
     }
 
+    if !is_decisive(best_score) && best_score > beta {
+        best_score = i32::midpoint(best_score, beta);
+    }
+
     let flag = if best_score >= beta {
         Bound::Lower
     } else if best_score > original_alpha {


### PR DESCRIPTION
<pre>
https://test.expositor.dev/test/385/
<b>  LLR</b> +3.07 (−2.94<sub>LO</sub> +2.94<sub>HI</sub> BOUNDS <i>for</i> +0.00<sub>LO</sub> +3.00<sub>HI</sub> ELO)
<b>  ELO</b> +1.90 ± 1.47 (+0.42<sub>LO</sub> +3.37<sub>HI</sub>)
<b> CONF</b> 8+0.08 SEC (1 THREAD 16 MB CACHE)
<b>GAMES</b> 56012 (13824<sub>W</sub><sup>24.7%</sup> 28670<sub>D</sub><sup>51.2%</sup> 13518<sub>L</sub><sup>24.1%</sup>)
<b>PENTA</b> 215<sub>+2</sub> 6696<sub>+1</sub> 14445<sub>+0</sub> 6480<sub>−1</sub> 170<sub>−2</sub>
</pre>