### PR TITLE
Deeper singular reductions, permit LMR extensions.

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -1397,13 +1397,12 @@ pub fn alpha_beta<NT: NodeType>(
                 // multi-cut: if a move other than the best one beats beta,
                 // then we can cut with relatively high confidence.
                 return value;
+            } else if tte.value >= beta {
+                // a sort of light multi-cut.
+                extension = -3 + i32::from(NT::PV);
             } else if cut_node {
                 // produce a strong negative extension if we didn't fail low on a cut-node.
                 extension = -2;
-            } else if tte.value >= beta || tte.value <= alpha {
-                // the tt_value >= beta condition is a sort of "light multi-cut"
-                // the tt_value <= alpha condition is from Weiss (https://github.com/TerjeKir/weiss/compare/2a7b4ed0...effa8349/).
-                extension = -1;
             } else {
                 // no extension.
                 extension = 0;
@@ -1462,7 +1461,7 @@ pub fn alpha_beta<NT: NodeType>(
             };
             // perform a zero-window search
             let mut new_depth = depth + extension;
-            let reduced_depth = (new_depth - r).clamp(0, new_depth);
+            let reduced_depth = (new_depth - r).clamp(0, new_depth + 1);
             score = -alpha_beta::<OffPV>(l_pv, t, reduced_depth, -alpha - 1, -alpha, true);
             // simple reduction for any future searches
             t.ss[height].reduction = 1024;


### PR DESCRIPTION
<pre>
https://test.expositor.dev/test/387/
<b>  LLR</b> +2.95 (−2.94<sub>LO</sub> +2.94<sub>HI</sub> BOUNDS <i>for</i> +0.00<sub>LO</sub> +3.00<sub>HI</sub> ELO)
<b>  ELO</b> +1.97 ± 1.54 (+0.44<sub>LO</sub> +3.51<sub>HI</sub>)
<b> CONF</b> 40+0.4 SEC (1 THREAD 128 MB CACHE)
<b>GAMES</b> 46284 (10961<sub>W</sub><sup>23.7%</sup> 24625<sub>D</sub><sup>53.2%</sup> 10698<sub>L</sub><sup>23.1%</sup>)
<b>PENTA</b> 39<sub>+2</sub> 5441<sub>+1</sub> 12440<sub>+0</sub> 5188<sub>−1</sub> 34<sub>−2</sub>
</pre>