### PR TITLE
Use TT-corrected eval more directly in SNMP.

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -1094,11 +1094,11 @@ pub fn alpha_beta<NT: NodeType>(
         // this is a generalisation of stand_pat in quiescence search.
         if !t.ss[height].ttpv
             && depth < 9
-            && !is_decisive(eval)
-            && eval >= beta
-            && eval - rfp_margin(&t.board, &t.info, depth, improving, correction) >= beta
-            && (tt_move.is_none() || tt_capture.is_some())
             && beta > -MINIMUM_TB_WIN_SCORE
+            && eval < MINIMUM_TB_WIN_SCORE
+            && eval >= beta
+            && (tt_move.is_none() || tt_capture.is_some())
+            && eval - rfp_margin(&t.board, &t.info, depth, improving, correction) >= beta
         {
             return beta + (eval - beta) / 3;
         }


### PR DESCRIPTION
<pre>
https://test.expositor.dev/test/405/
<b>  LLR</b> −2.96 (−2.94<sub>LO</sub> +2.94<sub>HI</sub> BOUNDS <i>for</i> +0.00<sub>LO</sub> +3.00<sub>HI</sub> ELO)
<b>  ELO</b> +0.38 ± 0.89 (−0.50<sub>LO</sub> +1.27<sub>HI</sub>)
<b> CONF</b> 8+0.08 SEC (1 THREAD 16 MB CACHE)
<b>GAMES</b> 156672 (37733<sub>W</sub><sup>24.1%</sup> 81378<sub>D</sub><sup>51.9%</sup> 37561<sub>L</sub><sup>24.0%</sup>)
<b>PENTA</b> 536<sub>+2</sub> 18778<sub>+1</sub> 39820<sub>+0</sub> 18726<sub>−1</sub> 476<sub>−2</sub>
</pre>

<pre>
https://test.expositor.dev/test/407/
<b>  LLR</b> +2.96 (−2.94<sub>LO</sub> +2.94<sub>HI</sub> BOUNDS <i>for</i> −3.00<sub>LO</sub> +0.00<sub>HI</sub> ELO)
<b>  ELO</b> +2.98 ± 2.66 (+0.32<sub>LO</sub> +5.64<sub>HI</sub>)
<b> CONF</b> 40+0.4 SEC (1 THREAD 128 MB CACHE)
<b>GAMES</b> 15740 (3726<sub>W</sub><sup>23.7%</sup> 8423<sub>D</sub><sup>53.5%</sup> 3591<sub>L</sub><sup>22.8%</sup>)
<b>PENTA</b> 13<sub>+2</sub> 1913<sub>+1</sub> 4148<sub>+0</sub> 1788<sub>−1</sub> 8<sub>−2</sub>
</pre>