### PR TITLE
Remove legality check for the TT-move in the picker.

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -590,8 +590,6 @@ pub fn quiescence<NT: NodeType>(
         None
     };
 
-    let tt_move = tt_hit.and_then(|e| e.mov);
-
     t.ss[height].ttpv = NT::PV || tt_hit.is_some_and(|hit| hit.was_pv);
 
     let raw_eval;
@@ -664,7 +662,7 @@ pub fn quiescence<NT: NodeType>(
 
     while let Some(m) = move_picker.next(t) {
         t.tt.prefetch(t.board.key_after(m));
-        if Some(m) != tt_move && !t.board.is_legal(m) {
+        if !t.board.is_legal(m) {
             continue;
         }
         let is_tactical = t.board.is_tactical(m);
@@ -1209,7 +1207,7 @@ pub fn alpha_beta<NT: NodeType>(
         move_picker.skip_quiets = true;
         while let Some(m) = move_picker.next(t) {
             t.tt.prefetch(t.board.key_after(m));
-            if Some(m) != tt_move && !t.board.is_legal(m) {
+            if !t.board.is_legal(m) {
                 continue;
             }
             t.ss[height].searching = Some(m);
@@ -1272,7 +1270,7 @@ pub fn alpha_beta<NT: NodeType>(
         }
 
         t.tt.prefetch(t.board.key_after(m));
-        if Some(m) != tt_move && !t.board.is_legal(m) {
+        if !t.board.is_legal(m) {
             continue;
         }
 


### PR DESCRIPTION
<pre>
https://test.expositor.dev/test/409/
<b>  LLR</b> +3.04 (−2.94<sub>LO</sub> +2.94<sub>HI</sub> BOUNDS <i>for</i> −5.00<sub>LO</sub> +0.00<sub>HI</sub> ELO)
<b>  ELO</b> +2.43 ± 3.48 (−1.05<sub>LO</sub> +5.91<sub>HI</sub>)
<b> CONF</b> 4+0.04 SEC (1 THREAD 16 MB CACHE)
<b>GAMES</b> 10152 (2563<sub>W</sub><sup>25.2%</sup> 5097<sub>D</sub><sup>50.2%</sup> 2492<sub>L</sub><sup>24.5%</sup>)
<b>PENTA</b> 50<sub>+2</sub> 1175<sub>+1</sub> 2701<sub>+0</sub> 1096<sub>−1</sub> 54<sub>−2</sub>
</pre>