### PR TITLE
Limit time usage to 60% of clock.

### DIFF
--- a/src/timemgmt.rs
+++ b/src/timemgmt.rs
@@ -10,7 +10,10 @@ use crate::{
     transpositiontable::Bound,
 };
 
+/// A buffer to account for communication between the engine and the client.
 const MOVE_OVERHEAD: u64 = 30;
+/// The fraction per mille that we are ever allowed to use of the bank.
+const MAX_BANK_USABLE: u64 = 600;
 
 pub const STRONG_FORCED_TM_FRAC: u32 = 386;
 pub const WEAK_FORCED_TM_FRAC: u32 = 627;
@@ -98,7 +101,7 @@ impl SearchLimit {
     ) -> (u64, u64, u64) {
         // The very highest amount of time we are
         // willing to search in a position, ever.
-        let max_time = (our_clock * 95 / 100).saturating_sub(MOVE_OVERHEAD);
+        let max_time = (our_clock * MAX_BANK_USABLE / 1000).saturating_sub(MOVE_OVERHEAD);
 
         // The maximum time we can spend searching before forcibly stopping:
         let hard_time_window = (our_clock * u64::from(conf.hard_window_frac) / 100).min(max_time);


### PR DESCRIPTION
<pre>
https://test.expositor.dev/test/467/
<b>  LLR</b> +3.09 (−2.94<sub>LO</sub> +2.94<sub>HI</sub> BOUNDS <i>for</i> −3.00<sub>LO</sub> +0.00<sub>HI</sub> ELO)
<b>  ELO</b> +1.92 ± 2.19 (−0.27<sub>LO</sub> +4.11<sub>HI</sub>)
<b> CONF</b> 8+0.08 SEC (1 THREAD 16 MB CACHE)
<b>GAMES</b> 22812 (5565<sub>W</sub><sup>24.4%</sup> 11808<sub>D</sub><sup>51.8%</sup> 5439<sub>L</sub><sup>23.8%</sup>)
<b>PENTA</b> 71<sub>+2</sub> 2481<sub>+1</sub> 6426<sub>+0</sub> 2359<sub>−1</sub> 69<sub>−2</sub>
</pre>