### PR TITLE
Avoid futility pruning for moves delivering check.

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -1323,7 +1323,11 @@ pub fn alpha_beta<NT: NodeType>(
             let fp_margin = lmr_depth * t.info.conf.futility_coeff_1
                 + t.info.conf.futility_coeff_0
                 + stat_score / 128;
-            if is_quiet && lmr_depth < 6 && static_eval + fp_margin <= alpha {
+            if is_quiet
+                && lmr_depth < 6
+                && static_eval + fp_margin <= alpha
+                && !t.board.gives_check(m)
+            {
                 move_picker.skip_quiets = true;
             }
         }


### PR DESCRIPTION
<pre>
https://viri.dev/test/593/
<b>  LLR</b> −2.96 (−2.94<sub>LO</sub> +2.94<sub>HI</sub> BOUNDS <i>for</i> +0.00<sub>LO</sub> +3.00<sub>HI</sub> ELO)
<b>  ELO</b> +0.18 ± 1.01 (−0.83<sub>LO</sub> +1.19<sub>HI</sub>)
<b> CONF</b> 40+0.4 SEC (1 THREAD 128 MB CACHE)
<b>GAMES</b> 106218 (25148<sub>W</sub><sup>23.7%</sup> 55978<sub>D</sub><sup>52.7%</sup> 25092<sub>L</sub><sup>23.6%</sup>)
<b>PENTA</b> 62<sub>+2</sub> 12142<sub>+1</sub> 28766<sub>+0</sub> 12068<sub>−1</sub> 71<sub>−2</sub>
</pre>