### PR TITLE
Remove intermediate buffering in threat update.

### DIFF
--- a/src/nnue/accumulator.rs
+++ b/src/nnue/accumulator.rs
@@ -85,8 +85,9 @@ mod simd {
     }
 
     /// Apply add/subtract updates in place.
-    pub fn vector_update_inplace_threat(
-        input: &mut Align64<[i16; L1_SIZE]>,
+    pub fn vector_update_threats(
+        src_acc: &Align64<[i16; L1_SIZE]>,
+        dst_acc: &mut Align64<[i16; L1_SIZE]>,
         bucket: &Align64<[i8; THREAT_FEATURES * L1_SIZE]>,
         adds: &[ThreatFeatureIndex],
         subs: &[ThreatFeatureIndex],
@@ -114,7 +115,7 @@ mod simd {
             for i in 0..L1_SIZE / UNROLL {
                 let unroll_offset = i * UNROLL;
                 for (r_idx, reg) in registers.iter_mut().enumerate() {
-                    let src = input.as_ptr().add(unroll_offset + r_idx * I16_CHUNK);
+                    let src = src_acc.as_ptr().add(unroll_offset + r_idx * I16_CHUNK);
                     *reg = simd::load_i16(src);
                 }
                 // todo: is load_extend_i8 the fastest way to do this?
@@ -132,7 +133,7 @@ mod simd {
                     }
                 }
                 for (r_idx, reg) in registers.iter().enumerate() {
-                    let dst = input.as_mut_ptr().add(unroll_offset + r_idx * I16_CHUNK);
+                    let dst = dst_acc.as_mut_ptr().add(unroll_offset + r_idx * I16_CHUNK);
                     simd::store_i16(dst, *reg);
                 }
             }

--- a/src/nnue/network.rs
+++ b/src/nnue/network.rs
@@ -1800,9 +1800,7 @@ impl NNUEState {
             }
         }
 
-        // just copy & use vector_update_inplace.
-        tgt.copy_from_slice(&**src);
-        accumulator::vector_update_inplace_threat(tgt, &nnue_params.l0_threat, &adds, &subs);
+        accumulator::vector_update_threats(src, tgt, &nnue_params.l0_threat, &adds, &subs);
     }
 
     /// Evaluate the final layer on the partial activations.


### PR DESCRIPTION
<pre>
https://viri.dev/test/610/
<b>  LLR</b> +3.04 (−2.94<sub>LO</sub> +2.94<sub>HI</sub> BOUNDS <i>for</i> +0.00<sub>LO</sub> +3.00<sub>HI</sub> ELO)
<b>  ELO</b> +3.21 ± 2.18 (+1.03<sub>LO</sub> +5.39<sub>HI</sub>)
<b> CONF</b> 4+0.04 SEC (1 THREAD 16 MB CACHE)
<b>GAMES</b> 25552 (6486<sub>W</sub><sup>25.4%</sup> 12816<sub>D</sub><sup>50.2%</sup> 6250<sub>L</sub><sup>24.5%</sup>)
<b>PENTA</b> 116<sub>+2</sub> 2997<sub>+1</sub> 6779<sub>+0</sub> 2775<sub>−1</sub> 109<sub>−2</sub>
</pre>