### PR TITLE
Add prefetching for threat weights.

### DIFF
--- a/src/nnue/accumulator.rs
+++ b/src/nnue/accumulator.rs
@@ -92,8 +92,17 @@ mod simd {
         adds: &[ThreatFeatureIndex],
         subs: &[ThreatFeatureIndex],
     ) {
+        #[cfg(target_arch = "x86_64")]
+        use std::arch::x86_64::{_MM_HINT_T0, _mm_prefetch};
+
         const REGISTERS: usize = 16;
         const UNROLL: usize = I16_CHUNK * REGISTERS;
+
+        if adds.is_empty() && subs.is_empty() {
+            dst_acc.copy_from_slice(&**src_acc);
+            return;
+        }
+
         // SAFETY: we never hold multiple mutable references, we never mutate immutable memory,
         // we use iterators to ensure that we're staying in-bounds, etc.
         unsafe {
@@ -101,15 +110,17 @@ mod simd {
             let mut sub_blocks = ArrayVec::<_, 128>::new();
             for &add_index in adds {
                 let add_index = add_index.index() * L1_SIZE;
-                add_blocks.push(slice_to_aligned(
-                    bucket.get_unchecked(add_index..add_index + L1_SIZE),
-                ));
+                let slice = slice_to_aligned(bucket.get_unchecked(add_index..add_index + L1_SIZE));
+                #[cfg(target_arch = "x86_64")]
+                _mm_prefetch(crate::util::from_ref(slice).cast::<i8>(), _MM_HINT_T0);
+                add_blocks.push(slice);
             }
             for &sub_index in subs {
                 let sub_index = sub_index.index() * L1_SIZE;
-                sub_blocks.push(slice_to_aligned(
-                    bucket.get_unchecked(sub_index..sub_index + L1_SIZE),
-                ));
+                let slice = slice_to_aligned(bucket.get_unchecked(sub_index..sub_index + L1_SIZE));
+                #[cfg(target_arch = "x86_64")]
+                _mm_prefetch(crate::util::from_ref(slice).cast::<i8>(), _MM_HINT_T0);
+                sub_blocks.push(slice);
             }
             let mut registers = [simd::zero_i16(); REGISTERS];
             for i in 0..L1_SIZE / UNROLL {


### PR DESCRIPTION
<pre>
https://viri.dev/test/631/
<b>  LLR</b> +2.95 (−2.94<sub>LO</sub> +2.94<sub>HI</sub> BOUNDS <i>for</i> +0.00<sub>LO</sub> +3.00<sub>HI</sub> ELO)
<b>  ELO</b> +1.98 ± 1.56 (+0.43<sub>LO</sub> +3.54<sub>HI</sub>)
<b> CONF</b> 4+0.04 SEC (1 THREAD 16 MB CACHE)
<b>GAMES</b> 48906 (12332<sub>W</sub><sup>25.2%</sup> 24521<sub>D</sub><sup>50.1%</sup> 12053<sub>L</sub><sup>24.6%</sup>)
<b>PENTA</b> 233<sub>+2</sub> 5454<sub>+1</sub> 13348<sub>+0</sub> 5195<sub>−1</sub> 223<sub>−2</sub>
</pre>