### PR TITLE
Marginally improve TI documentation

### DIFF
--- a/src/nnue/geometry.rs
+++ b/src/nnue/geometry.rs
@@ -1,6 +1,7 @@
+use std::ops::{BitAnd, Not};
+
 #[cfg(target_feature = "avx512vbmi")]
 mod vbmi;
-use std::ops::{BitAnd, Not};
 
 #[cfg(target_feature = "avx512vbmi")]
 pub use vbmi::*;

--- a/src/nnue/geometry.rs
+++ b/src/nnue/geometry.rs
@@ -1,5 +1,7 @@
 #[cfg(target_feature = "avx512vbmi")]
 mod vbmi;
+use std::ops::{BitAnd, Not};
+
 #[cfg(target_feature = "avx512vbmi")]
 pub use vbmi::*;
 
@@ -31,7 +33,67 @@ impl Bit {
     pub const KING   : Self = Self(0x40);
 }
 
-pub type BitRays = u64;
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Default)]
+#[repr(transparent)]
+pub struct BitRays(u64);
+
+impl BitRays {
+    pub const NON_KNIGHT: BitRays = BitRays(0xFEFE_FEFE_FEFE_FEFE);
+
+    #[allow(dead_code)]
+    pub fn inner(self) -> u64 {
+        self.0
+    }
+
+    pub fn count_ones(self) -> u32 {
+        self.0.count_ones()
+    }
+
+    pub fn flip(self) -> Self {
+        Self(self.0.rotate_right(32))
+    }
+}
+
+impl BitAnd for BitRays {
+    type Output = Self;
+
+    fn bitand(self, rhs: Self) -> Self::Output {
+        BitRays(self.0 & rhs.0)
+    }
+}
+
+impl Not for BitRays {
+    type Output = Self;
+
+    fn not(self) -> Self::Output {
+        BitRays(!self.0)
+    }
+}
+
+impl IntoIterator for BitRays {
+    type Item = usize;
+    type IntoIter = BitRaysIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        BitRaysIter(self.0)
+    }
+}
+
+pub struct BitRaysIter(u64);
+
+impl Iterator for BitRaysIter {
+    type Item = usize;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.0 == 0 {
+            None
+        } else {
+            let lsb = self.0.trailing_zeros();
+            self.0 &= self.0 - 1;
+            Some(lsb as usize)
+        }
+    }
+}
 
 /// Given a square, return a permutation that allows the transformation
 /// of a mailbox into a ray-vector, as specified in
@@ -113,19 +175,19 @@ pub const PIECE_TO_BIT: [Bit; 16] = {
 /// feature-set we use, which fully excludes king threats
 /// – ordinarily, they’d be `0x02_02_02_02_02_02_02_02`.
 const OUTGOING_THREATS: [BitRays; 12] = {
-    let mut lut = [0; 12];
-    lut[Piece::WP as usize] = 0x02_00_00_00_00_00_02_00;
-    lut[Piece::BP as usize] = 0x00_00_02_00_02_00_00_00;
-    lut[Piece::WN as usize] = 0x01_01_01_01_01_01_01_01;
-    lut[Piece::BN as usize] = 0x01_01_01_01_01_01_01_01;
-    lut[Piece::WB as usize] = 0xFE_00_FE_00_FE_00_FE_00;
-    lut[Piece::BB as usize] = 0xFE_00_FE_00_FE_00_FE_00;
-    lut[Piece::WR as usize] = 0x00_FE_00_FE_00_FE_00_FE;
-    lut[Piece::BR as usize] = 0x00_FE_00_FE_00_FE_00_FE;
-    lut[Piece::WQ as usize] = 0xFE_FE_FE_FE_FE_FE_FE_FE;
-    lut[Piece::BQ as usize] = 0xFE_FE_FE_FE_FE_FE_FE_FE;
-    lut[Piece::WK as usize] = 0; // ignore king threats
-    lut[Piece::BK as usize] = 0; // ignore king threats
+    let mut lut = [BitRays(0); 12];
+    lut[Piece::WP as usize] = BitRays(0x02_00_00_00_00_00_02_00);
+    lut[Piece::BP as usize] = BitRays(0x00_00_02_00_02_00_00_00);
+    lut[Piece::WN as usize] = BitRays(0x01_01_01_01_01_01_01_01);
+    lut[Piece::BN as usize] = BitRays(0x01_01_01_01_01_01_01_01);
+    lut[Piece::WB as usize] = BitRays(0xFE_00_FE_00_FE_00_FE_00);
+    lut[Piece::BB as usize] = BitRays(0xFE_00_FE_00_FE_00_FE_00);
+    lut[Piece::WR as usize] = BitRays(0x00_FE_00_FE_00_FE_00_FE);
+    lut[Piece::BR as usize] = BitRays(0x00_FE_00_FE_00_FE_00_FE);
+    lut[Piece::WQ as usize] = BitRays(0xFE_FE_FE_FE_FE_FE_FE_FE);
+    lut[Piece::BQ as usize] = BitRays(0xFE_FE_FE_FE_FE_FE_FE_FE);
+    lut[Piece::WK as usize] = BitRays(0); // ignore king threats
+    lut[Piece::BK as usize] = BitRays(0); // ignore king threats
     lut
 };
 
@@ -171,9 +233,9 @@ pub const INCOMING_SLIDERS_MASK: [Bit; 64] = {
 /// Given some bit-rays, selects every ray that has a nonzero
 /// element, and fills the whole ray.
 #[inline]
-pub fn ray_fill(mut br: BitRays) -> BitRays {
-    br = (br.wrapping_add(0x7E_7E_7E_7E_7E_7E_7E_7E)) & 0x80_80_80_80_80_80_80_80;
-    br.wrapping_sub(br >> 7)
+pub fn ray_fill(br: BitRays) -> BitRays {
+    let br = (br.0.wrapping_add(0x7E_7E_7E_7E_7E_7E_7E_7E)) & 0x80_80_80_80_80_80_80_80;
+    BitRays(br.wrapping_sub(br >> 7))
 }
 
 /// Determine which of `closest` are seen by this piece.

--- a/src/nnue/geometry/avx2.rs
+++ b/src/nnue/geometry/avx2.rs
@@ -1,10 +1,10 @@
 #![expect(clippy::cast_sign_loss, clippy::undocumented_unsafe_blocks)]
 
 use std::arch::x86_64::{
-    __m128i, __m256i, _mm_loadu_si128, _mm256_and_si256, _mm256_andnot_si256, _mm256_blendv_epi8,
+    __m128i, __m256i, _mm256_and_si256, _mm256_andnot_si256, _mm256_blendv_epi8,
     _mm256_broadcastsi128_si256, _mm256_cmpeq_epi8, _mm256_loadu_si256, _mm256_movemask_epi8,
     _mm256_permute2x128_si256, _mm256_set1_epi8, _mm256_setzero_si256, _mm256_shuffle_epi8,
-    _mm256_slli_epi64,
+    _mm256_slli_epi64, _mm_loadu_si128,
 };
 
 use crate::{
@@ -33,7 +33,7 @@ impl Vector {
         unsafe {
             let a = u64::from(_mm256_movemask_epi8(self.raw[0]) as u32);
             let b = u64::from(_mm256_movemask_epi8(self.raw[1]) as u32);
-            a | (b << 32)
+            BitRays(a | (b << 32))
         }
     }
 
@@ -175,8 +175,8 @@ pub fn closest_occupied(bits: Vector) -> BitRays {
             ],
         };
         let occupied = !unoccupied.mask();
-        let o = occupied | 0x8181_8181_8181_8181;
-        (o ^ o.wrapping_sub(0x0303_0303_0303_0303)) & occupied
+        let o = occupied.0 | 0x8181_8181_8181_8181;
+        BitRays(o ^ o.wrapping_sub(0x0303_0303_0303_0303)) & occupied
     }
 }
 
@@ -214,7 +214,7 @@ pub fn incoming_sliders(bits: Vector, closest: BitRays) -> BitRays {
                 ),
             ],
         };
-        !v.mask() & closest & 0xFEFE_FEFE_FEFE_FEFE
+        !v.mask() & closest & BitRays::NON_KNIGHT
     }
 }
 

--- a/src/nnue/geometry/neon.rs
+++ b/src/nnue/geometry/neon.rs
@@ -167,7 +167,7 @@ pub fn closest_occupied(bits: Vector) -> BitRays {
         };
         let occupied = occupied_vec.to_mask();
         let o = occupied | 0x8181_8181_8181_8181;
-        (o ^ o.wrapping_sub(0x0303_0303_0303_0303)) & occupied
+        BitRays((o ^ o.wrapping_sub(0x0303_0303_0303_0303)) & occupied)
     }
 }
 
@@ -182,7 +182,7 @@ pub fn incoming_attackers(bits: Vector, closest: BitRays) -> BitRays {
                 vtstq_u8(bits.raw[3], mask.raw[3]),
             ],
         };
-        v.to_mask() & closest
+        BitRays(v.to_mask()) & closest
     }
 }
 
@@ -197,7 +197,7 @@ pub fn incoming_sliders(bits: Vector, closest: BitRays) -> BitRays {
                 vtstq_u8(bits.raw[3], mask.raw[3]),
             ],
         };
-        v.to_mask() & closest & 0xFEFE_FEFE_FEFE_FEFE
+        BitRays(v.to_mask()) & closest & BitRays::NON_KNIGHT
     }
 }
 
@@ -212,6 +212,6 @@ pub fn test_bit(bits: Vector, bit: Bit) -> BitRays {
                 vtstq_u8(bits.raw[3], king_mask),
             ],
         };
-        v.to_mask()
+        BitRays(v.to_mask())
     }
 }

--- a/src/nnue/geometry/vbmi.rs
+++ b/src/nnue/geometry/vbmi.rs
@@ -5,9 +5,9 @@
 )]
 
 use std::arch::x86_64::{
-    __m128i, __m512i, _mm_loadu_si128, _mm512_broadcast_i32x4, _mm512_loadu_si512,
-    _mm512_mask_blend_epi8, _mm512_maskz_shuffle_epi8, _mm512_permutexvar_epi8, _mm512_set1_epi8,
-    _mm512_shuffle_i64x2, _mm512_test_epi8_mask, _mm512_testn_epi8_mask,
+    __m128i, __m512i, _mm512_broadcast_i32x4, _mm512_loadu_si512, _mm512_mask_blend_epi8,
+    _mm512_maskz_shuffle_epi8, _mm512_permutexvar_epi8, _mm512_set1_epi8, _mm512_shuffle_i64x2,
+    _mm512_test_epi8_mask, _mm512_testn_epi8_mask, _mm_loadu_si128,
 };
 
 use crate::{
@@ -88,24 +88,29 @@ pub fn closest_occupied(bits: Vector) -> BitRays {
     unsafe {
         let occupied = _mm512_test_epi8_mask(bits.raw, bits.raw);
         let o = occupied | 0x8181_8181_8181_8181;
-        (o ^ o.wrapping_sub(0x0303_0303_0303_0303)) & occupied
+        BitRays((o ^ o.wrapping_sub(0x0303_0303_0303_0303)) & occupied)
     }
 }
 
 pub fn incoming_attackers(bits: Vector, closest: BitRays) -> BitRays {
     unsafe {
         let mask = _mm512_loadu_si512(INCOMING_THREATS_MASK.as_ptr().cast());
-        _mm512_test_epi8_mask(bits.raw, mask) & closest
+        BitRays(_mm512_test_epi8_mask(bits.raw, mask)) & closest
     }
 }
 
 pub fn incoming_sliders(bits: Vector, closest: BitRays) -> BitRays {
     unsafe {
         let mask = _mm512_loadu_si512(INCOMING_SLIDERS_MASK.as_ptr().cast());
-        _mm512_test_epi8_mask(bits.raw, mask) & closest & 0xFEFE_FEFE_FEFE_FEFE
+        BitRays(_mm512_test_epi8_mask(bits.raw, mask)) & closest & BitRays::NON_KNIGHT
     }
 }
 
 pub fn test_bit(bits: Vector, bit: Bit) -> BitRays {
-    unsafe { _mm512_test_epi8_mask(bits.raw, _mm512_set1_epi8(bit.0 as i8)) }
+    unsafe {
+        BitRays(_mm512_test_epi8_mask(
+            bits.raw,
+            _mm512_set1_epi8(bit.0 as i8),
+        ))
+    }
 }

--- a/src/nnue/network/threat_updates.rs
+++ b/src/nnue/network/threat_updates.rs
@@ -7,7 +7,7 @@ use crate::{
         types::Square,
     },
     nnue::{
-        geometry,
+        geometry::{self, BitRays},
         network::{ThreatFeatureUpdate, ThreatUpdateBuffer},
     },
 };
@@ -51,9 +51,9 @@ impl Direction for Incoming {
 #[cfg(target_feature = "avx512vbmi")]
 mod vbmi {
     use std::arch::x86_64::{
-        __m128i, _mm_storeu_si128, _mm_unpackhi_epi16, _mm_unpacklo_epi8, _mm_unpacklo_epi16,
-        _mm512_castsi512_si128, _mm512_mask_mov_epi8, _mm512_maskz_compress_epi8,
-        _mm512_permutex2var_epi8, _mm512_set_epi8, _mm512_set1_epi16, _mm512_storeu_si512,
+        __m128i, _mm512_castsi512_si128, _mm512_mask_mov_epi8, _mm512_maskz_compress_epi8,
+        _mm512_permutex2var_epi8, _mm512_set1_epi16, _mm512_set_epi8, _mm512_storeu_si512,
+        _mm_storeu_si128, _mm_unpackhi_epi16, _mm_unpacklo_epi16, _mm_unpacklo_epi8,
     };
 
     use crate::{
@@ -61,8 +61,8 @@ mod vbmi {
         nnue::{
             geometry,
             network::{
-                ThreatUpdateBuffer,
                 threat_updates::{AddSub, Direction},
+                ThreatUpdateBuffer,
             },
         },
     };
@@ -94,8 +94,8 @@ mod vbmi {
             let pair1 = _mm512_set1_epi16(piece as i16 | ((sq as i16) << 8));
 
             // non-focus:
-            let pair2_sq = _mm512_maskz_compress_epi8(br, indices.raw);
-            let pair2_piece = _mm512_maskz_compress_epi8(br, rays.raw);
+            let pair2_sq = _mm512_maskz_compress_epi8(br.inner(), indices.raw);
+            let pair2_piece = _mm512_maskz_compress_epi8(br.inner(), rays.raw);
             let pair2 = _mm512_permutex2var_epi8(pair2_piece, pair2_shuffle, pair2_sq);
 
             let mask = if Dir::OUTGOING {
@@ -134,12 +134,12 @@ mod vbmi {
 
             debug_assert_eq!(count, sliders.count_ones());
 
-            let p1 = _mm512_castsi512_si128(_mm512_maskz_compress_epi8(sliders, rays.raw));
-            let sq1 = _mm512_castsi512_si128(_mm512_maskz_compress_epi8(sliders, idxs.raw));
+            let p1 = _mm512_castsi512_si128(_mm512_maskz_compress_epi8(sliders.inner(), rays.raw));
+            let sq1 = _mm512_castsi512_si128(_mm512_maskz_compress_epi8(sliders.inner(), idxs.raw));
             let rays = rays.flip();
             let idxs = idxs.flip();
-            let p2 = _mm512_castsi512_si128(_mm512_maskz_compress_epi8(victims, rays.raw));
-            let sq2 = _mm512_castsi512_si128(_mm512_maskz_compress_epi8(victims, idxs.raw));
+            let p2 = _mm512_castsi512_si128(_mm512_maskz_compress_epi8(victims.inner(), rays.raw));
+            let sq2 = _mm512_castsi512_si128(_mm512_maskz_compress_epi8(victims.inner(), idxs.raw));
 
             let pair1 = _mm_unpacklo_epi8(p1, sq1);
             let pair2 = _mm_unpacklo_epi8(p2, sq2);
@@ -169,12 +169,12 @@ mod vbmi {
 #[cfg(not(target_feature = "avx512vbmi"))]
 mod generic {
     use crate::{
-        chess::{piece::Piece, squareset::SquareSet, types::Square},
+        chess::{piece::Piece, types::Square},
         nnue::{
             geometry,
             network::{
-                ThreatFeatureUpdate, ThreatUpdateBuffer,
                 threat_updates::{AddSub, Direction},
+                ThreatFeatureUpdate, ThreatUpdateBuffer,
             },
         },
     };
@@ -193,7 +193,7 @@ mod generic {
             let others = std::mem::transmute::<geometry::Vector, [Piece; 64]>(rays);
             let other_sqs = std::mem::transmute::<geometry::Vector, [Square; 64]>(indices);
 
-            for i in SquareSet::from_inner(br) {
+            for i in br {
                 let other = others[i];
                 let other_sq = other_sqs[i];
 
@@ -244,14 +244,11 @@ mod generic {
             let pieces = std::mem::transmute::<geometry::Vector, [Piece; 64]>(rays);
             let squares = std::mem::transmute::<geometry::Vector, [Square; 64]>(idxs);
 
-            let sliders = SquareSet::from_inner(sliders);
-            let victims = SquareSet::from_inner(victims);
-
             for (slider_idx, victim_idx) in sliders.into_iter().zip(victims) {
                 let attacker = pieces[slider_idx];
                 let from = squares[slider_idx];
-                let victim = pieces[victim_idx.wrapping_add(32)];
-                let to = squares[victim_idx.wrapping_add(32)];
+                let victim = pieces[(victim_idx + 32) % 64];
+                let to = squares[(victim_idx + 32) % 64];
 
                 let feature = ThreatFeatureUpdate {
                     attacker,
@@ -307,9 +304,16 @@ pub fn on_change<Op: AddSub>(
     }
 
     // find discovered threats, from sliders looking through the focus square.
-    // this is somewhat arcane, but one has it on good authority that it finds
-    // all valid discovered threats ^^
-    let victim_mask = (closest & non_king & 0xFEFE_FEFE_FEFE_FEFE).rotate_right(32);
+    //
+    // ray_fill detects if there is a piece anywhere within the 8 bits that make up a ray.
+    // Rotation of the bitrays by 32 causes a 180 degree rotation of the rays, so the south ray
+    // becomes the north ray, the south east ray becomes the north west ray, etc.
+    //
+    // A discovered threat exists if a victim exists on a ray opposite a slider, for example,
+    // if we have a pawn on the North ray and a rook on the South ray, then a discovered
+    // threat exists from the rook to the pawn.
+    let victim_mask = (closest & non_king & BitRays::NON_KNIGHT).flip();
+    // answer the question: do the sliders have a victim on the opposite ray?
     let valid = geometry::ray_fill(victim_mask) & geometry::ray_fill(incoming_sliders);
 
     push_discovered::<Op>(
@@ -398,8 +402,8 @@ pub fn on_move(
         push_focus::<Add, Incoming>(updates, dst_idxs, dst_rays, dst_incoming, new_piece, dst);
     }
 
-    let src_victim_mask = (src_closest & src_non_king & 0xFEFE_FEFE_FEFE_FEFE).rotate_right(32);
-    let dst_victim_mask = (dst_closest & dst_non_king & 0xFEFE_FEFE_FEFE_FEFE).rotate_right(32);
+    let src_victim_mask = (src_closest & src_non_king & BitRays::NON_KNIGHT).flip();
+    let dst_victim_mask = (dst_closest & dst_non_king & BitRays::NON_KNIGHT).flip();
     let src_valid = geometry::ray_fill(src_victim_mask) & geometry::ray_fill(src_sliders);
     let dst_valid = geometry::ray_fill(dst_victim_mask) & geometry::ray_fill(dst_sliders);
 
@@ -427,10 +431,10 @@ mod tests {
 
     use crate::{
         chess::{
-            board::{Board, movegen::attacks_by_type},
+            board::{movegen::attacks_by_type, Board},
             piece::PieceType,
         },
-        nnue::network::{UpdateBuffer, feature::ThreatFeatureIndex},
+        nnue::network::{feature::ThreatFeatureIndex, UpdateBuffer},
     };
 
     use super::*;
@@ -641,7 +645,7 @@ mod tests {
 
     use crate::{
         chess::piece::Colour,
-        nnue::network::{L1_SIZE, NNUEParams, NNUEState, feature::threat_index},
+        nnue::network::{feature::threat_index, NNUEParams, NNUEState, L1_SIZE},
         util::Align64,
     };
 


### PR DESCRIPTION
* Do not use SquareSet to represent a BitRays; Square to me implies square indexing.
* Introduce BitRays::NON_KNIGHT constant.
* Introduce BitRays::flip and document how discovered threats are found.

Bench: 3684965