### PR TITLE
Use checksum to mitigate cluster tearing.

### DIFF
--- a/src/transpositiontable.rs
+++ b/src/transpositiontable.rs
@@ -166,12 +166,6 @@ struct TTClusterMemory {
     memory: [AtomicU64; 4],
 }
 
-#[repr(C, align(32))]
-struct TTCluster {
-    entries: [TTEntry; 3],
-    padding: [u8; 2],
-}
-
 impl TTClusterMemory {
     pub fn load(&self) -> TTCluster {
         let a = self.memory[0].load(Ordering::Relaxed);
@@ -203,6 +197,18 @@ const _CLUSTER_SIZE: () = assert!(
     size_of::<TTClusterMemory>() == 32,
     "TT Cluster size is suboptimal."
 );
+
+#[repr(C, align(32))]
+struct TTCluster {
+    entries: [TTEntry; 3],
+    coherer: u16,
+}
+
+impl TTCluster {
+    pub fn checksum(&self) -> u16 {
+        self.entries[0].key ^ self.entries[1].key ^ self.entries[2].key
+    }
+}
 
 #[derive(Debug)]
 pub struct TT {
@@ -397,6 +403,7 @@ impl TTView<'_> {
                 evaluation: eval.try_into().expect("eval with value outwith i16"),
             };
             cluster.entries[idx] = write;
+            cluster.coherer = cluster.checksum();
             self.table[cluster_index].store(cluster);
         }
     }
@@ -406,6 +413,10 @@ impl TTView<'_> {
         let key = TT::pack_key(key);
 
         let cluster = self.table[index].load();
+
+        if cluster.checksum() != cluster.coherer {
+            return None;
+        }
 
         for entry in cluster.entries {
             if entry.key != key {


### PR DESCRIPTION
this is a total vanity change ^^

<pre>
https://viri.dev/test/643/
<b>  LLR</b> −1.24 (−2.94<sub>LO</sub> +2.94<sub>HI</sub> BOUNDS <i>for</i> +0.00<sub>LO</sub> +3.00<sub>HI</sub> ELO)
<b>  ELO</b> +0.14 ± 1.68 (−1.54<sub>LO</sub> +1.83<sub>HI</sub>)
<b> CONF</b> 4+0.04 SEC (8 THREADS 2 MB CACHE)
<b>GAMES</b> 41062 (9913<sub>W</sub><sup>24.1%</sup> 21253<sub>D</sub><sup>51.8%</sup> 9896<sub>L</sub><sup>24.1%</sup>)
<b>PENTA</b> 67<sub>+2</sub> 4884<sub>+1</sub> 10658<sub>+0</sub> 4843<sub>−1</sub> 79<sub>−2</sub>
</pre>