### PR TITLE
Fix UB, optimise for MIRI.

### DIFF
--- a/src/chess/board/mod.rs
+++ b/src/chess/board/mod.rs
@@ -1634,6 +1634,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // too slow.
     fn fen_round_trip() {
         use crate::chess::board::Board;
         use std::{

--- a/src/chess/board/movegen.rs
+++ b/src/chess/board/movegen.rs
@@ -1012,6 +1012,7 @@ mod tests {
     };
 
     #[test]
+    #[cfg_attr(miri, ignore)] // too slow.
     fn staged_matches_full() {
         let positions = bench::BENCH_POSITIONS
             .into_iter()

--- a/src/chess/board/san.rs
+++ b/src/chess/board/san.rs
@@ -553,6 +553,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // too slow.
     fn roundtrip() {
         // Test that san() and parse_san() are inverses
         let positions = [

--- a/src/chess/fen.rs
+++ b/src/chess/fen.rs
@@ -527,6 +527,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // too slow.
     fn epd_perftsuite() {
         let (success, failures) = parse_epd_file("assets/epds/perftsuite.epd");
         assert!(failures.is_empty(), "failures:\n{}", failures.join("\n"));
@@ -534,6 +535,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // too slow.
     fn epd_frcperftsuite() {
         let (success, failures) = parse_epd_file("assets/epds/frcperftsuite.epd");
         assert!(failures.is_empty(), "failures:\n{}", failures.join("\n"));
@@ -541,6 +543,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // too slow.
     fn epd_wac() {
         let (success, failures) = parse_epd_file("assets/epds/wac.epd");
         assert!(failures.is_empty(), "failures:\n{}", failures.join("\n"));
@@ -548,6 +551,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // too slow.
     fn epd_arasan21() {
         let (success, failures) = parse_epd_file("assets/epds/arasan21.epd");
         assert!(failures.is_empty(), "failures:\n{}", failures.join("\n"));
@@ -555,6 +559,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // too slow.
     fn epd_tbtest() {
         let (success, failures) = parse_epd_file("assets/epds/tbtest.epd");
         assert!(failures.is_empty(), "failures:\n{}", failures.join("\n"));
@@ -562,6 +567,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // too slow.
     fn epd_all_files() {
         // Stress test: parse all EPD files
         let epd_files = [

--- a/src/historytable.rs
+++ b/src/historytable.rs
@@ -110,23 +110,17 @@ impl<T> ThreatsHistoryTable<T> {
 
 impl ThreatsHistoryTable<PieceToTable> {
     pub fn clear(&mut self) {
-        self.table
-            .iter_mut()
-            .flatten()
-            .flat_map(|h| &mut h.table)
-            .flatten()
-            .for_each(|x| *x = 0);
+        for sub_table in self.table.as_flattened_mut() {
+            sub_table.table.as_flattened_mut().fill(0);
+        }
     }
 }
 
 impl ThreatsHistoryTable<FromToTable> {
     pub fn clear(&mut self) {
-        self.table
-            .iter_mut()
-            .flatten()
-            .flat_map(|h| &mut h.table)
-            .flatten()
-            .for_each(|x| *x = 0);
+        for sub_table in self.table.as_flattened_mut() {
+            sub_table.table.as_flattened_mut().fill(0);
+        }
     }
 }
 
@@ -166,12 +160,9 @@ impl CaptureHistoryTable {
     }
 
     pub fn clear(&mut self) {
-        self.table
-            .iter_mut()
-            .flatten()
-            .flat_map(|h| &mut h.table)
-            .flatten()
-            .for_each(|x| *x = 0);
+        for sub_table in self.table.as_flattened_mut() {
+            sub_table.table.as_flattened_mut().fill(0);
+        }
     }
 }
 
@@ -211,12 +202,9 @@ impl DoubleHistoryTable {
     }
 
     pub fn clear(&mut self) {
-        self.table
-            .iter_mut()
-            .flatten()
-            .flat_map(|h| &mut h.table)
-            .flatten()
-            .for_each(|x| *x = 0);
+        for sub_table in self.table.as_flattened_mut() {
+            sub_table.table.as_flattened_mut().fill(0);
+        }
     }
 }
 
@@ -256,11 +244,9 @@ impl HashHistoryTable {
     }
 
     pub fn clear(&mut self) {
-        self.table
-            .iter_mut()
-            .flat_map(|h| &mut h.table)
-            .flatten()
-            .for_each(|x| *x = 0);
+        for sub_table in &mut self.table {
+            sub_table.table.as_flattened_mut().fill(0);
+        }
     }
 }
 
@@ -300,7 +286,7 @@ impl CorrectionHistoryTable {
     }
 
     pub fn clear(&mut self) {
-        self.table.iter_mut().for_each(|t| t.fill(0));
+        self.table.as_flattened_mut().fill(0);
     }
 
     #[allow(clippy::cast_possible_truncation)]

--- a/src/nnue/geometry/avx2.rs
+++ b/src/nnue/geometry/avx2.rs
@@ -55,20 +55,20 @@ impl Vector {
 }
 
 pub struct Permutation {
-    pub indices: Vector,
+    pub indexes: Vector,
     pub invalid: Vector,
 }
 
 pub fn permutation_for(focus: Square) -> Permutation {
     unsafe {
-        let indices = Vector::cast(&PERMUTATION[focus.index()]);
+        let indexes = Vector::cast(&PERMUTATION[focus.index()]);
         let invalid = Vector {
             raw: [
-                _mm256_cmpeq_epi8(indices.raw[0], _mm256_set1_epi8(0x80u8.cast_signed())),
-                _mm256_cmpeq_epi8(indices.raw[1], _mm256_set1_epi8(0x80u8.cast_signed())),
+                _mm256_cmpeq_epi8(indexes.raw[0], _mm256_set1_epi8(0x80u8.cast_signed())),
+                _mm256_cmpeq_epi8(indexes.raw[1], _mm256_set1_epi8(0x80u8.cast_signed())),
             ],
         };
-        Permutation { indices, invalid }
+        Permutation { indexes, invalid }
     }
 }
 
@@ -98,12 +98,12 @@ fn permute_mailbox_inner(permutation: &Permutation, masked_mailbox: Vector) -> (
                 half_swizzle(
                     masked_mailbox.raw[0],
                     masked_mailbox.raw[1],
-                    permutation.indices.raw[0],
+                    permutation.indexes.raw[0],
                 ),
                 half_swizzle(
                     masked_mailbox.raw[0],
                     masked_mailbox.raw[1],
-                    permutation.indices.raw[1],
+                    permutation.indexes.raw[1],
                 ),
             ],
         };
@@ -137,6 +137,7 @@ pub fn permute_mailbox_ignoring(
     mailbox: &[Option<Piece>; 64],
     ignore: Square,
 ) -> (Vector, Vector) {
+    const NO_PIECE: i8 = unsafe { std::mem::transmute::<Option<Piece>, i8>(None) };
     unsafe {
         let iota = Align([
             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
@@ -145,11 +146,7 @@ pub fn permute_mailbox_ignoring(
         ]);
         let iota = Vector::load(iota.0.as_ptr());
         let ignore_vec = _mm256_set1_epi8(ignore.inner().cast_signed());
-        // None<Piece> is represented as 12 due to niche optimisation.
-        const {
-            assert!(12 == std::mem::transmute::<Option<Piece>, u8>(None));
-        }
-        let none_vec = _mm256_set1_epi8(12);
+        let none_vec = _mm256_set1_epi8(NO_PIECE);
         let mb = Vector::load(mailbox.as_ptr().cast::<u8>());
         let masked_mailbox = Vector {
             raw: [

--- a/src/nnue/geometry/neon.rs
+++ b/src/nnue/geometry/neon.rs
@@ -57,34 +57,34 @@ impl Vector {
 }
 
 pub struct Permutation {
-    pub indices: Vector,
+    pub indexes: Vector,
     pub valid: Vector,
 }
 
 pub fn permutation_for(focus: Square) -> Permutation {
     unsafe {
-        let indices = Vector::load(PERMUTATION[focus.index()].as_ptr());
+        let indexes = Vector::load(PERMUTATION[focus.index()].as_ptr());
         let valid = Vector {
             raw: [
                 vmvnq_u8(vreinterpretq_u8_s8(vshrq_n_s8(
-                    vreinterpretq_s8_u8(indices.raw[0]),
+                    vreinterpretq_s8_u8(indexes.raw[0]),
                     7,
                 ))),
                 vmvnq_u8(vreinterpretq_u8_s8(vshrq_n_s8(
-                    vreinterpretq_s8_u8(indices.raw[1]),
+                    vreinterpretq_s8_u8(indexes.raw[1]),
                     7,
                 ))),
                 vmvnq_u8(vreinterpretq_u8_s8(vshrq_n_s8(
-                    vreinterpretq_s8_u8(indices.raw[2]),
+                    vreinterpretq_s8_u8(indexes.raw[2]),
                     7,
                 ))),
                 vmvnq_u8(vreinterpretq_u8_s8(vshrq_n_s8(
-                    vreinterpretq_s8_u8(indices.raw[3]),
+                    vreinterpretq_s8_u8(indexes.raw[3]),
                     7,
                 ))),
             ],
         };
-        Permutation { indices, valid }
+        Permutation { indexes, valid }
     }
 }
 
@@ -100,10 +100,10 @@ fn permute_mailbox_inner(permutation: &Permutation, mailbox: &Vector) -> (Vector
         );
         let permuted = Vector {
             raw: [
-                vqtbl4q_u8(mb, permutation.indices.raw[0]),
-                vqtbl4q_u8(mb, permutation.indices.raw[1]),
-                vqtbl4q_u8(mb, permutation.indices.raw[2]),
-                vqtbl4q_u8(mb, permutation.indices.raw[3]),
+                vqtbl4q_u8(mb, permutation.indexes.raw[0]),
+                vqtbl4q_u8(mb, permutation.indexes.raw[1]),
+                vqtbl4q_u8(mb, permutation.indexes.raw[2]),
+                vqtbl4q_u8(mb, permutation.indexes.raw[3]),
             ],
         };
         let bits = Vector {
@@ -131,6 +131,7 @@ pub fn permute_mailbox_ignoring(
     mailbox: &[Option<Piece>; 64],
     ignore: Square,
 ) -> (Vector, Vector) {
+    const NO_PIECE: u8 = unsafe { std::mem::transmute::<Option<Piece>, u8>(None) };
     unsafe {
         let iota = Align64([
             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
@@ -138,11 +139,7 @@ pub fn permute_mailbox_ignoring(
             46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63,
         ]);
         let iota = Vector::load(iota.0.as_ptr());
-        // None<Piece> is represented as 12 due to niche optimisation.
-        const {
-            assert!(12 == std::mem::transmute::<Option<Piece>, u8>(None));
-        }
-        let none_vec = vdupq_n_u8(12);
+        let none_vec = vdupq_n_u8(NO_PIECE);
         let ignore_vec = vdupq_n_u8(ignore.inner());
 
         let mb = Vector::load(mailbox.as_ptr().cast::<u8>());

--- a/src/nnue/geometry/vbmi.rs
+++ b/src/nnue/geometry/vbmi.rs
@@ -34,16 +34,16 @@ impl Vector {
 }
 
 pub struct Permutation {
-    pub indices: Vector,
+    pub indexes: Vector,
     pub valid: u64,
 }
 
 pub fn permutation_for(focus: Square) -> Permutation {
     unsafe {
-        let indices = _mm512_loadu_si512(PERMUTATION[focus.index()].as_ptr().cast());
-        let valid = _mm512_testn_epi8_mask(indices, _mm512_set1_epi8(0x80u8 as i8));
+        let indexes = _mm512_loadu_si512(PERMUTATION[focus.index()].as_ptr().cast());
+        let valid = _mm512_testn_epi8_mask(indexes, _mm512_set1_epi8(0x80u8 as i8));
         Permutation {
-            indices: Vector { raw: indices },
+            indexes: Vector { raw: indexes },
             valid,
         }
     }
@@ -57,7 +57,7 @@ pub fn permute_mailbox(
         let lut = _mm512_broadcast_i32x4(_mm_loadu_si128(PIECE_TO_BIT.as_ptr().cast::<__m128i>()));
 
         let masked_mailbox = _mm512_loadu_si512(mailbox.as_ptr().cast());
-        let permuted = _mm512_permutexvar_epi8(permutation.indices.raw, masked_mailbox);
+        let permuted = _mm512_permutexvar_epi8(permutation.indexes.raw, masked_mailbox);
         let bits = _mm512_maskz_shuffle_epi8(permutation.valid, lut, permuted);
         (Vector { raw: permuted }, Vector { raw: bits })
     }
@@ -68,20 +68,17 @@ pub fn permute_mailbox_ignoring(
     mailbox: &[Option<Piece>; 64],
     ignore: Square,
 ) -> (Vector, Vector) {
+    const NO_PIECE: i8 = unsafe { std::mem::transmute::<Option<Piece>, i8>(None) };
     unsafe {
         let lut = _mm512_broadcast_i32x4(_mm_loadu_si128(PIECE_TO_BIT.as_ptr().cast::<__m128i>()));
 
         let ignore_mask: u64 = 1 << ignore.inner();
-        const {
-            assert!(12 == std::mem::transmute::<Option<Piece>, u8>(None));
-        }
         let masked_mailbox = _mm512_mask_blend_epi8(
             ignore_mask,
             _mm512_loadu_si512(mailbox.as_ptr().cast()),
-            // None<Piece> is represented as 12 due to niche optimisation.
-            _mm512_set1_epi8(12),
+            _mm512_set1_epi8(NO_PIECE),
         );
-        let permuted = _mm512_permutexvar_epi8(permutation.indices.raw, masked_mailbox);
+        let permuted = _mm512_permutexvar_epi8(permutation.indexes.raw, masked_mailbox);
         let bits = _mm512_maskz_shuffle_epi8(permutation.valid, lut, permuted);
         (Vector { raw: permuted }, Vector { raw: bits })
     }

--- a/src/nnue/network.rs
+++ b/src/nnue/network.rs
@@ -6,7 +6,7 @@ use std::{
     mem::size_of,
     ops::Deref,
     path::Path,
-    sync::{Mutex, OnceLock},
+    sync::{LazyLock, Mutex, OnceLock},
     time::Duration,
 };
 
@@ -775,6 +775,15 @@ impl NNUEParams {
         static LOCK: Mutex<()> = Mutex::new(());
         // additionally, we'd quite like to cache the results of this function.
         static CACHED: OnceLock<Mmap> = OnceLock::new();
+
+        // If we’re under MIRI, this function is way too slow.
+        if cfg!(miri) {
+            static MIRI_NULL_NETWORK: LazyLock<Box<NNUEParams>> = LazyLock::new(|| {
+                // Safety: All bitpatterns of Self are valid.
+                unsafe { Box::new_zeroed().assume_init() }
+            });
+            return Ok(&*MIRI_NULL_NETWORK);
+        }
 
         if EMBEDDED_NNUE_VERBATIM {
             // if we're using the verbatim network, we don't need to decompress anything.

--- a/src/nnue/network/threat_updates.rs
+++ b/src/nnue/network/threat_updates.rs
@@ -301,7 +301,7 @@ mod generic {
     /// Add threats revealed by removal of some piece from
     /// some square, or blocked by arrival of such a piece
     /// on such a square. For direct threats → `push_focus`.
-    pub fn push_discovered<Op: AddSub>(
+    pub unsafe fn push_discovered<Op: AddSub>(
         updates: &mut ThreatUpdateBuffer,
         idxs: geometry::Vector,
         rays: geometry::Vector,
@@ -400,13 +400,16 @@ pub fn on_change<Op: AddSub>(
     // answer the question: do the sliders have a victim on the opposite ray?
     let valid = geometry::ray_fill(victim_mask) & geometry::ray_fill(incoming_sliders);
 
-    push_discovered::<Op>(
-        updates,
-        perm.indexes,
-        rays,
-        incoming_sliders & valid,
-        victim_mask & valid,
-    );
+    // Safety: idxs & rays have valid bit-patterns.
+    unsafe {
+        push_discovered::<Op>(
+            updates,
+            perm.indexes,
+            rays,
+            incoming_sliders & valid,
+            victim_mask & valid,
+        );
+    }
 }
 
 /// Given the transformation of a piece from one type into another,
@@ -497,20 +500,23 @@ pub fn on_move(
     let src_valid = geometry::ray_fill(src_victim_mask) & geometry::ray_fill(src_sliders);
     let dst_valid = geometry::ray_fill(dst_victim_mask) & geometry::ray_fill(dst_sliders);
 
-    push_discovered::<Sub>(
-        updates,
-        src_idxs,
-        src_rays,
-        src_sliders & src_valid,
-        src_victim_mask & src_valid,
-    );
-    push_discovered::<Add>(
-        updates,
-        dst_idxs,
-        dst_rays,
-        dst_sliders & dst_valid,
-        dst_victim_mask & dst_valid,
-    );
+    // Safety: idxs & rays have valid bit-patterns.
+    unsafe {
+        push_discovered::<Sub>(
+            updates,
+            src_idxs,
+            src_rays,
+            src_sliders & src_valid,
+            src_victim_mask & src_valid,
+        );
+        push_discovered::<Add>(
+            updates,
+            dst_idxs,
+            dst_rays,
+            dst_sliders & dst_valid,
+            dst_victim_mask & dst_valid,
+        );
+    }
 }
 
 #[cfg(test)]

--- a/src/nnue/network/threat_updates.rs
+++ b/src/nnue/network/threat_updates.rs
@@ -48,6 +48,45 @@ impl Direction for Incoming {
     const OUTGOING: bool = false;
 }
 
+#[cfg(debug_assertions)]
+#[expect(clippy::zero_prefixed_literal)]
+fn check_rays(rays: geometry::Vector) {
+    #[rustfmt::skip]
+    const VALID: [u8; 13] = [
+        00, 01, 02, 03, 04, 05,
+        06, 07, 08, 09, 10, 11,
+        // Safety: All bitpatterns of `u8` are valid.
+        unsafe { std::mem::transmute::<Option<Piece>, u8>(None) }
+    ];
+
+    // Safety: All bitpatterns of `u8` are valid.
+    let ray_bytes: [u8; size_of::<geometry::Vector>()] = unsafe { std::mem::transmute(rays) };
+
+    for byte in ray_bytes {
+        assert!(
+            VALID.contains(&byte),
+            "Got invalid byte for variants of Option<Piece>: {byte}"
+        );
+    }
+}
+
+#[cfg(debug_assertions)]
+fn check_indexes(squares: geometry::Vector) {
+    // Safety: All bitpatterns of `u8` are valid.
+    let square_bytes: [u8; size_of::<geometry::Vector>()] = unsafe { std::mem::transmute(squares) };
+
+    for byte in square_bytes {
+        // 0×80 is the sentinel for unused permutation slots.
+        // This value is selected s.t. a _mm256_shuffle_epi8
+        // zeroes containing lanes, as 0×80’s top bit is one.
+        // <3 https://en.algorithmica.org/hpc/simd/shuffling/
+        assert!(
+            byte < 64 || byte == 0x80,
+            "Got invalid byte for square index: {byte}"
+        );
+    }
+}
+
 #[cfg(target_feature = "avx512vbmi")]
 mod vbmi {
     use std::arch::x86_64::{
@@ -67,14 +106,23 @@ mod vbmi {
         },
     };
 
-    pub fn push_focus<Op: AddSub, Dir: Direction>(
+    /// Add threats directly related to a piece’s presence
+    /// on some square. These updates could be additive or
+    /// subtractive, and the threats are either inbound or
+    /// outbound from the piece. Also see `push_discovered`.
+    pub unsafe fn push_focus<Op: AddSub, Dir: Direction>(
         updates: &mut ThreatUpdateBuffer,
-        indices: geometry::Vector, // square indices
+        indexes: geometry::Vector, // square indexes
         rays: geometry::Vector,    // pieces on said squares
         br: geometry::BitRays,     // bitrays where set bit sees focus square
         piece: Piece,              // piece on the focus square
         sq: Square,                // the focus square
     ) {
+        #[cfg(debug_assertions)]
+        super::check_rays(rays);
+        #[cfg(debug_assertions)]
+        super::check_squares(indexes);
+
         // Safety: TODO
         unsafe {
             #[rustfmt::skip]
@@ -94,7 +142,7 @@ mod vbmi {
             let pair1 = _mm512_set1_epi16(piece as i16 | ((sq as i16) << 8));
 
             // non-focus:
-            let pair2_sq = _mm512_maskz_compress_epi8(br.inner(), indices.raw);
+            let pair2_sq = _mm512_maskz_compress_epi8(br.inner(), indexes.raw);
             let pair2_piece = _mm512_maskz_compress_epi8(br.inner(), rays.raw);
             let pair2 = _mm512_permutex2var_epi8(pair2_piece, pair2_shuffle, pair2_sq);
 
@@ -120,13 +168,21 @@ mod vbmi {
         }
     }
 
-    pub fn push_discovered<Op: AddSub>(
+    /// Add threats revealed by removal of some piece from
+    /// some square, or blocked by arrival of such a piece
+    /// on such a square. For direct threats → `push_focus`.
+    pub unsafe fn push_discovered<Op: AddSub>(
         updates: &mut ThreatUpdateBuffer,
         idxs: geometry::Vector,
         rays: geometry::Vector,
         sliders: geometry::BitRays,
         victims: geometry::BitRays,
     ) {
+        #[cfg(debug_assertions)]
+        super::check_rays(rays);
+        #[cfg(debug_assertions)]
+        super::check_squares(idxs);
+
         // Safety: TODO
         #[expect(clippy::cast_ptr_alignment)]
         unsafe {
@@ -179,23 +235,36 @@ mod generic {
         },
     };
 
-    pub fn push_focus<Op: AddSub, Dir: Direction>(
+    /// Add threats directly related to a piece’s presence
+    /// on some square. These updates could be additive or
+    /// subtractive, and the threats are either inbound or
+    /// outbound from the piece. Also see `push_discovered`.
+    pub unsafe fn push_focus<Op: AddSub, Dir: Direction>(
         updates: &mut ThreatUpdateBuffer,
-        indices: geometry::Vector, // square indices
+        indexes: geometry::Vector, // square indexes
         rays: geometry::Vector,    // pieces on said squares
         br: geometry::BitRays,     // bitrays where set bit sees focus square
         piece: Piece,              // piece on the focus square
         sq: Square,                // the focus square
     ) {
-        // Safety: ehhhhhhhh get back to me on that, geometry::Vector needs to be
-        // inconstructible w/out unsafe :(
+        #[cfg(debug_assertions)]
+        super::check_rays(rays);
+        #[cfg(debug_assertions)]
+        super::check_indexes(indexes);
+
+        // Safety: Caller must ensure that the contents of `rays`
+        // and `indexes` map to valid variants of `Option<Piece>`
+        // and `Square` (respectively), to license transmutation.
         unsafe {
-            let others = std::mem::transmute::<geometry::Vector, [Piece; 64]>(rays);
-            let other_sqs = std::mem::transmute::<geometry::Vector, [Square; 64]>(indices);
+            let others = std::mem::transmute::<geometry::Vector, [Option<Piece>; 64]>(rays);
+            let other_sqs = std::mem::transmute::<geometry::Vector, [u8; 64]>(indexes);
 
             for i in br {
-                let other = others[i];
-                let other_sq = other_sqs[i];
+                let other = others[i].unwrap_unchecked();
+                // Safety: `br` only has bits set for occupied slots,
+                // where the value is a valid square index in (0..64).
+                // The 0×80 sentinels in empty slots aren’t selected.
+                let other_sq = Square::new_unchecked(other_sqs[i]);
 
                 let attacker;
                 let from;
@@ -229,6 +298,9 @@ mod generic {
         }
     }
 
+    /// Add threats revealed by removal of some piece from
+    /// some square, or blocked by arrival of such a piece
+    /// on such a square. For direct threats → `push_focus`.
     pub fn push_discovered<Op: AddSub>(
         updates: &mut ThreatUpdateBuffer,
         idxs: geometry::Vector,
@@ -236,19 +308,28 @@ mod generic {
         sliders: geometry::BitRays,
         victims: geometry::BitRays,
     ) {
-        // Safety: ehhhhhhhh get back to me on that, geometry::Vector needs to be
-        // inconstructible w/out unsafe :(
+        #[cfg(debug_assertions)]
+        super::check_rays(rays);
+        #[cfg(debug_assertions)]
+        super::check_indexes(idxs);
+
+        // Safety: Caller must ensure that the contents of `rays`
+        // and `indexes` map to valid variants of `Option<Piece>`
+        // and `Square` (respectively), to license transmutation.
         unsafe {
             debug_assert_eq!(victims.count_ones(), sliders.count_ones());
 
-            let pieces = std::mem::transmute::<geometry::Vector, [Piece; 64]>(rays);
-            let squares = std::mem::transmute::<geometry::Vector, [Square; 64]>(idxs);
+            let pieces = std::mem::transmute::<geometry::Vector, [Option<Piece>; 64]>(rays);
+            let squares = std::mem::transmute::<geometry::Vector, [u8; 64]>(idxs);
 
             for (slider_idx, victim_idx) in sliders.into_iter().zip(victims) {
-                let attacker = pieces[slider_idx];
-                let from = squares[slider_idx];
-                let victim = pieces[(victim_idx + 32) % 64];
-                let to = squares[(victim_idx + 32) % 64];
+                let attacker = pieces[slider_idx].unwrap_unchecked();
+                // Safety: `br` only has bits set for occupied slots,
+                // where the value is a valid square index in (0..64).
+                // The 0×80 sentinels in empty slots aren’t selected.
+                let from = Square::new_unchecked(squares[slider_idx]);
+                let victim = pieces[(victim_idx + 32) % 64].unwrap_unchecked();
+                let to = Square::new_unchecked(squares[(victim_idx + 32) % 64]);
 
                 let feature = ThreatFeatureUpdate {
                     attacker,
@@ -299,8 +380,11 @@ pub fn on_change<Op: AddSub>(
 
     // push focus-square relative threats (kings are neither attackers nor victims)
     if piece.piece_type() != PieceType::King {
-        push_focus::<Op, Outgoing>(updates, perm.indices, rays, outgoing_threats, piece, sq);
-        push_focus::<Op, Incoming>(updates, perm.indices, rays, incoming_attackers, piece, sq);
+        // Safety: `perm.indexes` & rays have valid bit-patterns.
+        unsafe {
+            push_focus::<Op, Outgoing>(updates, perm.indexes, rays, outgoing_threats, piece, sq);
+            push_focus::<Op, Incoming>(updates, perm.indexes, rays, incoming_attackers, piece, sq);
+        }
     }
 
     // find discovered threats, from sliders looking through the focus square.
@@ -318,7 +402,7 @@ pub fn on_change<Op: AddSub>(
 
     push_discovered::<Op>(
         updates,
-        perm.indices,
+        perm.indexes,
         rays,
         incoming_sliders & valid,
         victim_mask & valid,
@@ -348,11 +432,14 @@ pub fn on_mutate(
     let incoming = geometry::incoming_attackers(bits, closest);
 
     debug_assert!(old_piece.piece_type() != PieceType::King);
-    push_focus::<Sub, Outgoing>(updates, perm.indices, rays, old_outgoing, old_piece, sq);
-    push_focus::<Sub, Incoming>(updates, perm.indices, rays, incoming, old_piece, sq);
-    if new_piece.piece_type() != PieceType::King {
-        push_focus::<Add, Outgoing>(updates, perm.indices, rays, new_outgoing, new_piece, sq);
-        push_focus::<Add, Incoming>(updates, perm.indices, rays, incoming, new_piece, sq);
+    // Safety: `perm.indexes` & rays have valid bit-patterns.
+    unsafe {
+        push_focus::<Sub, Outgoing>(updates, perm.indexes, rays, old_outgoing, old_piece, sq);
+        push_focus::<Sub, Incoming>(updates, perm.indexes, rays, incoming, old_piece, sq);
+        if new_piece.piece_type() != PieceType::King {
+            push_focus::<Add, Outgoing>(updates, perm.indexes, rays, new_outgoing, new_piece, sq);
+            push_focus::<Add, Incoming>(updates, perm.indexes, rays, incoming, new_piece, sq);
+        }
     }
 }
 
@@ -389,17 +476,20 @@ pub fn on_move(
     let src_sliders = geometry::incoming_sliders(src_bits, src_closest);
     let dst_sliders = geometry::incoming_sliders(dst_bits, dst_closest);
 
-    let src_idxs = src_perm.indices;
-    let dst_idxs = dst_perm.indices;
+    let src_idxs = src_perm.indexes;
+    let dst_idxs = dst_perm.indexes;
     debug_assert!(
         old_piece.piece_type() != PieceType::King || old_piece == new_piece,
         "cannot transmute to/from king"
     );
     if old_piece.piece_type() != PieceType::King {
-        push_focus::<Sub, Outgoing>(updates, src_idxs, src_rays, src_outgoing, old_piece, src);
-        push_focus::<Add, Outgoing>(updates, dst_idxs, dst_rays, dst_outgoing, new_piece, dst);
-        push_focus::<Sub, Incoming>(updates, src_idxs, src_rays, src_incoming, old_piece, src);
-        push_focus::<Add, Incoming>(updates, dst_idxs, dst_rays, dst_incoming, new_piece, dst);
+        // Safety: `perm.indexes` & rays have valid bit-patterns.
+        unsafe {
+            push_focus::<Sub, Outgoing>(updates, src_idxs, src_rays, src_outgoing, old_piece, src);
+            push_focus::<Add, Outgoing>(updates, dst_idxs, dst_rays, dst_outgoing, new_piece, dst);
+            push_focus::<Sub, Incoming>(updates, src_idxs, src_rays, src_incoming, old_piece, src);
+            push_focus::<Add, Incoming>(updates, dst_idxs, dst_rays, dst_incoming, new_piece, dst);
+        }
     }
 
     let src_victim_mask = (src_closest & src_non_king & BitRays::NON_KNIGHT).flip();
@@ -632,11 +722,13 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // too slow.
     fn startpos_all_moves() {
         check_all_moves(STARTPOS);
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // too slow.
     fn kiwipete_all_moves() {
         check_all_moves(KIWIPETE);
     }
@@ -649,23 +741,23 @@ mod tests {
         util::Align,
     };
 
-    /// Compute sorted threat feature indices for a given perspective.
-    fn threat_indices(board: &Board, colour: Colour) -> ArrayVec<usize, 128> {
+    /// Compute sorted threat feature indexes for a given perspective.
+    fn threat_indexes(board: &Board, colour: Colour) -> ArrayVec<usize, 128> {
         let king = board.state.bbs.king_sq(colour);
         let threats = collect_threats_simple(board);
-        let mut indices = threats
+        let mut indexes = threats
             .iter()
             .filter_map(|t| {
                 threat_index(colour, king, t.attacker, t.victim, t.from, t.to)
                     .map(ThreatFeatureIndex::index)
             })
             .collect::<ArrayVec<_, _>>();
-        indices.sort_unstable();
-        indices
+        indexes.sort_unstable();
+        indexes
     }
 
     #[test]
-    fn startpos_threat_indices() {
+    fn startpos_threat_indexes() {
         let board = Board::from_fen(STARTPOS).unwrap();
         let expected = [
             506, 525, 3878, 3879, 3899, 3900, 8351, 8449, 9240, 9344, 15603, 15604, 15605, 18512,
@@ -674,19 +766,19 @@ mod tests {
         ];
         // symmetric
         assert_eq!(
-            &threat_indices(&board, Colour::White),
+            &threat_indexes(&board, Colour::White),
             &expected[..],
             "white threats"
         );
         assert_eq!(
-            &threat_indices(&board, Colour::Black),
+            &threat_indexes(&board, Colour::Black),
             &expected[..],
             "black threats"
         );
     }
 
     #[test]
-    fn kiwipete_threat_indices() {
+    fn kiwipete_threat_indexes() {
         let board = Board::from_fen(KIWIPETE).unwrap();
 
         let white_expected = [
@@ -702,12 +794,12 @@ mod tests {
             53848, 55300, 56761,
         ];
         assert_eq!(
-            &threat_indices(&board, Colour::White),
+            &threat_indexes(&board, Colour::White),
             &white_expected[..],
             "white threats"
         );
         assert_eq!(
-            &threat_indices(&board, Colour::Black),
+            &threat_indexes(&board, Colour::Black),
             &black_expected[..],
             "black threats"
         );
@@ -723,9 +815,9 @@ mod tests {
 
         for colour in [Colour::White, Colour::Black] {
             // compute expected accumulator by summing weight rows
-            let indices = threat_indices(&board, colour);
+            let indexes = threat_indexes(&board, colour);
             let mut expected = Align([0i16; L1_SIZE]);
-            for &idx in &indices {
+            for &idx in &indexes {
                 let start = idx * L1_SIZE;
                 let row = &nnue_params.l0_threat[start..start + L1_SIZE];
                 for (e, &r) in expected.0.iter_mut().zip(row) {
@@ -747,11 +839,13 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // too slow.
     fn startpos_threat_accumulator() {
         check_threat_accumulator(STARTPOS);
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // too slow.
     fn kiwipete_threat_accumulator() {
         check_threat_accumulator(KIWIPETE);
     }

--- a/src/perft.rs
+++ b/src/perft.rs
@@ -196,6 +196,7 @@ mod tests {
                 .collect::<Vec<_>>()
                 .join(", ")
         });
+        #[cfg(not(miri))]
         assert_eq!(perft(&mut pos, 2), 2_039);
         // assert_eq!(perft(&mut pos, 3), 97_862);
         // assert_eq!(perft(&mut pos, 4), 4_085_603);
@@ -214,11 +215,13 @@ mod tests {
                 .join(", ")
         });
         assert_eq!(perft(&mut pos, 2), 400);
+        #[cfg(not(miri))]
         assert_eq!(perft(&mut pos, 3), 8_902);
         // assert_eq!(perft(&mut pos, 4), 197_281);
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // too slow.
     fn perft_nnue_start_position() {
         use super::*;
 
@@ -254,6 +257,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // too slow.
     fn perft_movepicker_start_position() {
         use super::*;
 
@@ -290,6 +294,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // too slow.
     fn perft_movepicker_hard_position() {
         use super::*;
         const TEST_FEN: &str =
@@ -328,6 +333,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // too slow.
     fn perft_movepicker_forward_promo_evasion() {
         use super::*;
         const TEST_FEN: &str = "r7/P2r4/7R/8/5p2/5K2/3p2P1/R5k1 b - - 0 1";
@@ -364,6 +370,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // too slow.
     fn perft_movepicker_forward_promo_evasion_and_capture() {
         use super::*;
         const TEST_FEN: &str = "r7/P2r4/7R/8/5p2/5K2/3p2P1/2R3k1 b - - 0 1";

--- a/src/searchinfo.rs
+++ b/src/searchinfo.rs
@@ -253,6 +253,7 @@ mod tests {
     static TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
     #[test]
+    #[cfg_attr(miri, ignore)] // too slow.
     fn go_mate_in_2_white() {
         let guard = TEST_LOCK.lock().unwrap();
 
@@ -293,6 +294,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // too slow.
     fn go_mated_in_2_white() {
         let guard = TEST_LOCK.lock().unwrap();
 
@@ -333,6 +335,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // too slow.
     fn go_mated_in_2_black() {
         let guard = TEST_LOCK.lock().unwrap();
 
@@ -373,6 +376,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // too slow.
     fn go_mate_in_2_black() {
         let guard = TEST_LOCK.lock().unwrap();
 

--- a/src/transpositiontable.rs
+++ b/src/transpositiontable.rs
@@ -8,7 +8,7 @@ use crate::{
     chess::chessmove::Move,
     evaluation::{MATE_SCORE, MINIMUM_MATE_SCORE, MINIMUM_TB_WIN_SCORE},
     threadpool::{self, ScopeExt},
-    util::{MEGABYTE, VALUE_NONE},
+    util::{MEGABYTE, SendPtr, VALUE_NONE},
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -57,13 +57,13 @@ unsafe fn threaded_memset_zero(
                 // with many threads we can hit this
                 break;
             }
-            // launder address
-            // Safety: Resultant pointer is in-bounds.
-            let addr = unsafe { ptr.add(start) } as usize;
+            // Safety: Resultant pointer is in-bounds, and each worker
+            // thread receives a disjoint region, so transfer is sound.
+            let slice_ptr = unsafe { SendPtr::new(ptr.add(start).cast::<u8>()) };
             let work = move || {
-                let slice_ptr = addr as *mut u8;
-                // Safety: Slice is in-bounds and is disjoint with the other
-                // threads' slices.
+                let slice_ptr = slice_ptr.get();
+                // Safety: Slice is in-bounds, and the region
+                // is disjoint with the other threads’ slices.
                 unsafe { std::ptr::write_bytes(slice_ptr, 0, end.checked_sub(start).unwrap()) };
             };
             handles.push(s.spawn_into(work, thread));
@@ -527,6 +527,7 @@ mod tests {
     use super::*;
 
     #[test]
+    #[cfg_attr(miri, ignore)] // too slow.
     fn memset_correct() {
         #![allow(clippy::undocumented_unsafe_blocks)]
         let mut x = vec![1u8; 2048];

--- a/src/util.rs
+++ b/src/util.rs
@@ -87,3 +87,28 @@ impl<T, const SIZE: usize> DerefMut for Align<[T; SIZE]> {
         &mut self.0
     }
 }
+
+/// An unsafe `Send` wrapper around a raw pointer, to transport a
+/// pointer to other threads while preserving provenance for MIRI.
+pub struct SendPtr<T>(*mut T);
+
+// Safety: Upon the head of the caller of `SendPtr::new`.
+unsafe impl<T> Send for SendPtr<T> {}
+
+impl<T> SendPtr<T> {
+    /// Wrap a raw pointer so it can be sent across threads.
+    ///
+    /// # Safety
+    ///
+    /// This allows you to move a raw pointer to another thread.
+    /// This isn’t inherently problematic, but be aware of what
+    /// may be thusly permitted, and what horrors may visit you.
+    pub const unsafe fn new(ptr: *mut T) -> Self {
+        Self(ptr)
+    }
+
+    /// Recover the wrapped pointer.
+    pub const fn get(self) -> *mut T {
+        self.0
+    }
+}


### PR DESCRIPTION
This PR sets the test suite up such that it can reasonably-well run under an invocation of:
```fish
$ RUSTFLAGS="-Ctarget-cpu=x86-64-v3" MIRIFLAGS=-Zmiri-disable-isolation cargo +nightly miri test
```

Most importantly, it fixes a case of Undefined Behaviour where we would transmute into illegal bit-patterns of Piece and Square.