### PR TITLE
Hoist LMR up to modify `lmr_depth`.

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -98,7 +98,8 @@ const LMR_CHECK_MUL: i32 = 1361;
 const LMR_CORR_MUL: i32 = 448;
 const LMR_ALPHA_RAISE_MUL: i32 = 384;
 const LMR_BASE_OFFSET: i32 = 226;
-const TTPV_LMR_DEPTH_MUL: i32 = 768;
+const TTPV_LMR_DEPTH_MUL: i32 = 2057;
+const LMR_DEPTH_OFFSET: i32 = -400;
 const MAIN_HISTORY: HistoryConfig = HistoryConfig::new(357, 226, 2241, 111, 561, 915);
 const CONT1_HISTORY: HistoryConfig = HistoryConfig::new(287, 150, 3729, 270, 267, 1178);
 const CONT2_HISTORY: HistoryConfig = HistoryConfig::new(177, 178, 1596, 280, 130, 943);
@@ -1338,9 +1339,6 @@ pub fn alpha_beta<NT: NodeType>(
             continue;
         }
 
-        let mut lmr_reduction = t.info.lm_table.lm_reduction(depth, moves_made);
-        lmr_reduction += t.info.conf.ttpv_lmr_depth_mul * i32::from(t.ss[height].ttpv);
-        let lmr_depth = std::cmp::max(depth - lmr_reduction / 1024, 0);
         let is_quiet = !t.board.is_tactical(m);
 
         let from = m.from();
@@ -1354,6 +1352,42 @@ pub fn alpha_beta<NT: NodeType>(
         } else {
             get_tactical_history(t, hist_to, moved, to_threat, m) / 32
         };
+
+        // calculation of LMR stuff.
+        let mut lmr_reduction = t.info.lm_table.lm_reduction(depth, moves_made + 1);
+        // tunable base offset
+        lmr_reduction += t.info.conf.lmr_base_offset;
+        // reduce more on non-PV nodes
+        lmr_reduction += i32::from(!NT::PV) * t.info.conf.lmr_non_pv_mul;
+        lmr_reduction -= i32::from(t.ss[height].ttpv) * t.info.conf.lmr_ttpv_mul;
+        // reduce more for ttpv positions whose cached score is <= alpha
+        lmr_reduction += i32::from(
+            t.ss[height].ttpv
+                && cached.is_some_and(|ce| ce.value != VALUE_NONE && ce.value <= alpha),
+        ) * t.info.conf.lmr_ttpv_fail_low_mul;
+        // reduce more on cut nodes
+        lmr_reduction += i32::from(cut_node) * t.info.conf.lmr_cut_node_mul;
+        // extend/reduce using the stat_score of the move
+        lmr_reduction -= stat_score * 1024 / t.info.conf.history_lmr_divisor;
+        // reduce refutation moves less
+        lmr_reduction -= i32::from(Some(m) == killer) * t.info.conf.lmr_refutation_mul;
+        // reduce more if not improving
+        lmr_reduction += i32::from(!improving) * t.info.conf.lmr_non_improving_mul;
+        // reduce more if the move from the transposition table is tactical
+        lmr_reduction += i32::from(tt_capture.is_some()) * t.info.conf.lmr_tt_capture_mul;
+        // reduce less when the static eval is way off-base
+        lmr_reduction -= correction.abs() * t.info.conf.lmr_corr_mul / 16384;
+        // reduce more for moves tried after several alpha-raises
+        lmr_reduction += alpha_raises * t.info.conf.lmr_alpha_raise_mul;
+
+        let lmr_depth = std::cmp::max(
+            depth
+                - (lmr_reduction
+                    + t.info.conf.ttpv_lmr_depth_mul * i32::from(t.ss[height].ttpv)
+                    + t.info.conf.lmr_depth_offset)
+                    / 1024,
+            0,
+        );
 
         // lmp & fp.
         if !NT::ROOT && !NT::PV && !in_check && best_score > -MINIMUM_TB_WIN_SCORE {
@@ -1442,35 +1476,10 @@ pub fn alpha_beta<NT: NodeType>(
             if NT::PV {
                 t.pv_scratch[height + 1].moves.clear();
             }
-            // calculation of LMR stuff
+            // finish off the LMR calculation started before the move was made:
             let r = if depth > 2 && moves_made > (1 + usize::from(NT::ROOT)) {
-                let mut r = t.info.lm_table.lm_reduction(depth, moves_made);
-                // tunable base offset
-                r += t.info.conf.lmr_base_offset;
-                // reduce more on non-PV nodes
-                r += i32::from(!NT::PV) * t.info.conf.lmr_non_pv_mul;
-                r -= i32::from(t.ss[height].ttpv) * t.info.conf.lmr_ttpv_mul;
-                // reduce more for ttpv positions whose cached score is <= alpha
-                r += i32::from(
-                    t.ss[height].ttpv
-                        && cached.is_some_and(|ce| ce.value != VALUE_NONE && ce.value <= alpha),
-                ) * t.info.conf.lmr_ttpv_fail_low_mul;
-                // reduce more on cut nodes
-                r += i32::from(cut_node) * t.info.conf.lmr_cut_node_mul;
-                // extend/reduce using the stat_score of the move
-                r -= stat_score * 1024 / t.info.conf.history_lmr_divisor;
-                // reduce refutation moves less
-                r -= i32::from(Some(m) == killer) * t.info.conf.lmr_refutation_mul;
-                // reduce more if not improving
-                r += i32::from(!improving) * t.info.conf.lmr_non_improving_mul;
-                // reduce more if the move from the transposition table is tactical
-                r += i32::from(tt_capture.is_some()) * t.info.conf.lmr_tt_capture_mul;
-                // reduce less if the move gives check
-                r -= i32::from(t.board.in_check()) * t.info.conf.lmr_check_mul;
-                // reduce less when the static eval is way off-base
-                r -= correction.abs() * t.info.conf.lmr_corr_mul / 16384;
-                // reduce more for moves tried after several alpha-raises
-                r += alpha_raises * t.info.conf.lmr_alpha_raise_mul;
+                // reduce less if the move gives check.
+                let r = lmr_reduction - i32::from(t.board.in_check()) * t.info.conf.lmr_check_mul;
 
                 t.ss[height].reduction = r;
                 r / 1024

--- a/src/search/parameters.rs
+++ b/src/search/parameters.rs
@@ -16,10 +16,10 @@ use crate::{
         EVAL_POLICY_UPDATE_MAX, FUTILITY_COEFF_0, FUTILITY_COEFF_1, HINDSIGHT_EXT_DEPTH,
         HINDSIGHT_RED_DEPTH, HINDSIGHT_RED_EVAL, HISTORY_LMR_DIVISOR, HISTORY_PRUNING_MARGIN,
         LMR_ALPHA_RAISE_MUL, LMR_BASE, LMR_BASE_OFFSET, LMR_CHECK_MUL, LMR_CORR_MUL,
-        LMR_CUT_NODE_MUL, LMR_DIVISION, LMR_NON_IMPROVING_MUL, LMR_NON_PV_MUL, LMR_REFUTATION_MUL,
-        LMR_TT_CAPTURE_MUL, LMR_TTPV_FAIL_LOW_MUL, LMR_TTPV_MUL, MAIN_HISTORY, MAIN_SEE_BOUND,
-        MAIN_STAT_SCORE_MUL, MAJOR_CORRHIST_WEIGHT, MINOR_CORRHIST_WEIGHT, NMP_DEPTH_MUL,
-        NMP_IMPROVING_MARGIN, NMP_REDUCTION_EVAL_DIVISOR, NONPAWN_CORRHIST_WEIGHT,
+        LMR_CUT_NODE_MUL, LMR_DEPTH_OFFSET, LMR_DIVISION, LMR_NON_IMPROVING_MUL, LMR_NON_PV_MUL,
+        LMR_REFUTATION_MUL, LMR_TT_CAPTURE_MUL, LMR_TTPV_FAIL_LOW_MUL, LMR_TTPV_MUL, MAIN_HISTORY,
+        MAIN_SEE_BOUND, MAIN_STAT_SCORE_MUL, MAJOR_CORRHIST_WEIGHT, MINOR_CORRHIST_WEIGHT,
+        NMP_DEPTH_MUL, NMP_IMPROVING_MARGIN, NMP_REDUCTION_EVAL_DIVISOR, NONPAWN_CORRHIST_WEIGHT,
         OPTIMISM_MATERIAL_BASE, OPTIMISM_OFFSET, PAWN_CORRHIST_WEIGHT, PAWN_HISTORY,
         PROBCUT_ADA_DIV, PROBCUT_ADA_OFFSET, PROBCUT_EVAL_DIV, PROBCUT_IMPROVING_MARGIN,
         PROBCUT_MARGIN, PROBCUT_SEE_SCALE, QS_FUTILITY, QS_SEE_BOUND, RAZORING_COEFF_0,
@@ -151,6 +151,7 @@ pub struct Config {
     pub eval_policy_update_max: i32,
     pub probcut_see_scale: i32,
     pub ttpv_lmr_depth_mul: i32,
+    pub lmr_depth_offset: i32,
 }
 
 impl Config {
@@ -241,6 +242,7 @@ impl Config {
             eval_policy_update_max: EVAL_POLICY_UPDATE_MAX,
             probcut_see_scale: PROBCUT_SEE_SCALE,
             ttpv_lmr_depth_mul: TTPV_LMR_DEPTH_MUL,
+            lmr_depth_offset: LMR_DEPTH_OFFSET,
         }
     }
 }
@@ -400,7 +402,8 @@ impl Config {
             OPTIMISM_MATERIAL_BASE = [self.optimism_mat_base],
             EVAL_POLICY_UPDATE_MAX = [self.eval_policy_update_max],
             PROBCUT_SEE_SCALE = [self.probcut_see_scale],
-            TTPV_LMR_DEPTH_MUL = [self.ttpv_lmr_depth_mul]
+            TTPV_LMR_DEPTH_MUL = [self.ttpv_lmr_depth_mul],
+            LMR_DEPTH_OFFSET = [self.lmr_depth_offset]
         ]
     }
 
@@ -530,7 +533,8 @@ impl Config {
             OPTIMISM_MATERIAL_BASE = [self.optimism_mat_base, 1, 8192, 256],
             EVAL_POLICY_UPDATE_MAX = [self.eval_policy_update_max, 1, 4096, 8],
             PROBCUT_SEE_SCALE = [self.probcut_see_scale, 1, 1024, 16],
-            TTPV_LMR_DEPTH_MUL = [self.ttpv_lmr_depth_mul, 1, 2048, 48]
+            TTPV_LMR_DEPTH_MUL = [self.ttpv_lmr_depth_mul, 1, 4096, 48],
+            LMR_DEPTH_OFFSET = [self.lmr_depth_offset, -4096, 4096, 96]
         ]
     }
 


### PR DESCRIPTION
<pre>
https://viri.dev/test/720/
<b>  LLR</b> +2.95 (−2.94<sub>LO</sub> +2.94<sub>HI</sub> BOUNDS <i>for</i> +0.00<sub>LO</sub> +3.00<sub>HI</sub> ELO)
<b>  ELO</b> +4.75 ± 2.75 (+2.00<sub>LO</sub> +7.49<sub>HI</sub>)
<b> CONF</b> 40+0.4 SEC (1 THREAD 128 MB CACHE)
<b>GAMES</b> 14202 (3561<sub>W</sub><sup>25.1%</sup> 7274<sub>D</sub><sup>51.2%</sup> 3367<sub>L</sub><sup>23.7%</sup>)
<b>PENTA</b> 5<sub>+2</sub> 1716<sub>+1</sub> 3858<sub>+0</sub> 1512<sub>−1</sub> 10<sub>−2</sub>
</pre>