### PR TITLE
Bugfix: clamping the best_score to avoid overflow

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -725,7 +725,7 @@ pub fn quiescence<NT: NodeType>(t: &mut ThreadData, mut alpha: i32, beta: i32) -
         key,
         height,
         best_move,
-        best_score,
+        best_score.clamp(-MATE_SCORE, MATE_SCORE),
         raw_eval,
         flag,
         0,


### PR DESCRIPTION
Fixes a rare edge case in which the score value could overflow the i16 data type.
Bench: 3609170