### PR TITLE
Fix for NNUE move targets in FRC.

### DIFF
--- a/src/chess/board/mod.rs
+++ b/src/chess/board/mod.rs
@@ -1093,7 +1093,7 @@ impl Board {
             self.state.bbs.pieces[PieceType::Pawn] & self.state.bbs.colours[Colour::Black];
         nnue.moves[nnue.current_acc] = MovedPiece {
             from: m.from(),
-            to: m.to(),
+            to: m.history_to_square(),
             piece,
         };
         nnue.psqt_correct[nnue.current_acc + 1] = [false; 2];


### PR DESCRIPTION
<pre>
https://viri.dev/test/755/
<b>  LLR</b> +2.97 (−2.94<sub>LO</sub> +2.94<sub>HI</sub> BOUNDS <i>for</i> −5.00<sub>LO</sub> +0.00<sub>HI</sub> ELO)
<b>  ELO</b> +5.51 ± 4.66 (+0.86<sub>LO</sub> +10.16<sub>HI</sub>)
<b> CONF</b> 8+0.08 SEC (1 THREAD 16 MB CACHE)
<b>GAMES</b> 5298 (1242<sub>W</sub><sup>23.4%</sup> 2898<sub>D</sub><sup>54.7%</sup> 1158<sub>L</sub><sup>21.9%</sup>)
<b>PENTA</b> 19<sub>+2</sub> 619<sub>+1</sub> 1460<sub>+0</sub> 529<sub>−1</sub> 22<sub>−2</sub>
</pre>