### PR TITLE
Accelerate relabelling via UE.

### DIFF
--- a/src/datagen.rs
+++ b/src/datagen.rs
@@ -1297,6 +1297,9 @@ fn relabel_batch(
 
             rollout.make_move(*mv, nnue_state);
             nnue_state.force(&rollout, nnue_params);
+            // We have to collapse the accumulator stack
+            // as games can last thousands of moves, but
+            // the accumulator arrays only go for ~128.
             nnue_state.collapse_stack();
             positions += 1;
         }

--- a/src/datagen.rs
+++ b/src/datagen.rs
@@ -1264,6 +1264,7 @@ fn relabel_batch(
 
     for game in &mut games {
         let mut rollout = game.initial_position();
+        nnue_state.reïnit_from(&rollout, nnue_params);
         for (mv, slot) in game.buffer_mut() {
             // we preserve decisive evaluations.
             // the ×2 is because we have changed the mate value
@@ -1275,11 +1276,6 @@ fn relabel_batch(
             let new_value = if is_decisive(value * 2) {
                 value
             } else {
-                // why reïnitialise every time?
-                // we cannot use efficient incremental updates,
-                // as games can run for >1000 ply, which is much
-                // beyond the 128 ply limit that we have at time of writing.
-                nnue_state.reïnit_from(&rollout, nnue_params);
                 // the raw output can be far outside the heuristic range (and
                 // even outside i16) in positions with insane material
                 // imbalances, so we clamp it.
@@ -1299,7 +1295,9 @@ fn relabel_batch(
 
             slot.set(new_value);
 
-            rollout.make_move_simple(*mv);
+            rollout.make_move(*mv, nnue_state);
+            nnue_state.force(&rollout, nnue_params);
+            nnue_state.collapse_stack();
             positions += 1;
         }
 

--- a/src/nnue/network.rs
+++ b/src/nnue/network.rs
@@ -1577,6 +1577,25 @@ impl NNUEState {
         }
     }
 
+    /// Shunt the top of the acc stack to the bottom.
+    #[cfg(any(test, feature = "datagen"))]
+    pub fn collapse_stack(&mut self) {
+        assert_eq!(self.psqt_correct[self.current_acc], [true; 2]);
+        assert_eq!(self.threat_correct[self.current_acc], [true; 2]);
+
+        if self.current_acc == 0 {
+            return;
+        }
+
+        let (bottom, top) = self.psqt_accumulators.split_at_mut(self.current_acc);
+        bottom[0].halves.clone_from(&top[0].halves);
+        let (bottom, top) = self.threat_accumulators.split_at_mut(self.current_acc);
+        bottom[0].halves.clone_from(&top[0].halves);
+        self.psqt_correct[0] = [true; 2];
+        self.threat_correct[0] = [true; 2];
+        self.current_acc = 0;
+    }
+
     pub fn hint_common_access(&mut self, pos: &Board, nnue_params: &NNUEParams) {
         self.hint_common_access_for_perspective::<White>(pos, nnue_params);
         self.hint_common_access_for_perspective::<Black>(pos, nnue_params);

--- a/src/nnue/network.rs
+++ b/src/nnue/network.rs
@@ -1578,7 +1578,7 @@ impl NNUEState {
     }
 
     /// Shunt the top of the acc stack to the bottom.
-    #[cfg(any(test, feature = "datagen"))]
+    #[cfg(feature = "datagen")]
     pub fn collapse_stack(&mut self) {
         assert_eq!(self.psqt_correct[self.current_acc], [true; 2]);
         assert_eq!(self.threat_correct[self.current_acc], [true; 2]);


### PR DESCRIPTION
’til now, we didn’t have a way of using UE while relabelling, because we’d blow the stack.